### PR TITLE
Rename secrets names in github workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
                           <servers>
                             <server>
                               <id>github</id>
-                              <username>${{ secrets.USERNAME }}</username>
-                              <password>${{ secrets.PERSONAL_TOKEN }}</password>
+                              <username>${{ secrets.BALLERINA_BOT_USERNAME }}</username>
+                              <password>${{ secrets.BALLERINA_BOT_TOKEN }}</password>
                             </server>
                           </servers>
                         </settings>' > ~/.m2/settings.xml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,8 +42,8 @@ jobs:
                           <servers>
                             <server>
                               <id>github</id>
-                              <username>${{ secrets.USERNAME }}</username>
-                              <password>${{ secrets.PERSONAL_TOKEN }}</password>
+                              <username>${{ secrets.BALLERINA_BOT_USERNAME }}</username>
+                              <password>${{ secrets.BALLERINA_BOT_TOKEN }}</password>
                             </server>
                           </servers>
                         </settings>' > ~/.m2/settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,8 @@ jobs:
                       <servers>
                         <server>
                           <id>github</id>
-                          <username>${{ secrets.USERNAME }}</username>
-                          <password>${{ secrets.PERSONAL_TOKEN }}</password>
+                          <username>${{ secrets.BALLERINA_BOT_USERNAME }}</username>
+                          <password>${{ secrets.BALLERINA_BOT_TOKEN }}</password>
                         </server>
                       </servers>
                     </settings>' > ~/.m2/settings.xml


### PR DESCRIPTION
## Purpose
> Update the Secrets names used in order to use organizational level secrets instead of adding inside the repository.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes