### PR TITLE
Bump versions for slbeta2 release of the connector 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         - name: Maven Build
           run: mvn clean install 
         - name: Ballerina Build
-          uses: ballerina-platform/ballerina-action/@master
+          uses: ballerina-platform/ballerina-action@slbeta2
           with:
             args:
               build -c --skip-tests redis
@@ -85,7 +85,7 @@ jobs:
             JAVA_HOME: /usr/lib/jvm/default-jvm 
             JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
         - name: Ballerina Push
-          uses: ballerina-platform/ballerina-action/@master
+          uses: ballerina-platform/ballerina-action@slbeta2
           with:
             args: 
               push

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.ballerinalang</groupId>
     <artifactId>connector-redis-parent</artifactId>
-    <version>0.99.7</version>
+    <version>1.0.1</version>
     <packaging>pom</packaging>
 
     <scm>

--- a/redis-utils/pom.xml
+++ b/redis-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>connector-redis-parent</artifactId>
         <groupId>org.ballerinalang</groupId>
-        <version>0.99.7</version>
+        <version>1.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/redis-utils/src/main/java/org/ballerinalang/redis/Constants.java
+++ b/redis-utils/src/main/java/org/ballerinalang/redis/Constants.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class Constants {
     static final int DEFAULT_REDIS_PORT = 6379;
     public static final String REDIS_EXCEPTION_OCCURRED = "{ballerinax/redis}Error";
-    public static final String REDIS_CONNECTOR_VERSION = "0.99.7";
+    public static final String REDIS_CONNECTOR_VERSION = "1.0.1";
 
     /**
      * Endpoint configuration constants.

--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -1,18 +1,15 @@
 [package]
 org="ballerinax"
 name = "redis"
-version="0.99.7"
+version="1.0.1"
 authors = ["Ballerina"]
 keywords = ["redis", "in-memory-database"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-redis"
 license = ["Apache-2.0"]
 
 [[platform.java11.dependency]]
-path = "../redis-utils/target/redis-0.99.7.jar"
+path = "../redis-utils/target/redis-1.0.1.jar"
 groupId = "org.ballerinalang"
 artifactId = "redis-utils"
 module = "redis-utils" 
-version="0.99.7"
-
-[build-options]
-taintCheck = true
+version="1.0.1"


### PR DESCRIPTION
## Purpose
- Bump connector version to 1.0.1
- Bump ballerina-action version to slbeta2
- Bump ballerinaLang version to 2.0.0-beta.2.1

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta2
