### PR TITLE
[SLBeta2] Bump commons-io from 2.6 to 2.7 in /redis-utils

### DIFF
--- a/redis-utils/pom.xml
+++ b/redis-utils/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
**Purpose**
Bumps commons-io from 2.6 to 2.7 to fix security issue.

**Related PR**
For master branch, the PR is sent by `dependabot`
https://github.com/ballerina-platform/module-ballerinax-redis/pull/75