### PR TITLE
Rename configuration record as ConnectionConfig

### DIFF
--- a/redis/Module.md
+++ b/redis/Module.md
@@ -19,7 +19,7 @@ import ballerinax/redis;
 ### Step 2: Create a new connector instance
 To access a Redis datasource, you must first create a `client` object. Create a client of the redis client type (i.e. `redis:Client`) and provide the necessary connection parameters. This creates a connection/pool of connections to the given Redis database. A method for creating a client with a Redis client can be found below.
 ```ballerina
-redis:ClientEndpointConfiguration redisConfig = {
+redis:ConnectionConfig redisConfig = {
     host: "localhost",
     password: "",
     options: {

--- a/redis/endpoint.bal
+++ b/redis/endpoint.bal
@@ -21,7 +21,7 @@ import ballerina/jballerina.java;
 # 
 @display {label: "Redis Client", iconPath: "RedisLogo.png"}
 public isolated client class Client {
-    private ClientEndpointConfiguration clientEndpointConfig = {};
+    private ConnectionConfig clientEndpointConfig = {};
 
     final handle datasource;
 
@@ -29,7 +29,7 @@ public isolated client class Client {
     #
     # + config - Configuration for the connector
     # + return - `http:Error` in case of failure to initialize or `null` if successfully initialized
-    public isolated function init(ClientEndpointConfiguration config) returns error? {
+    public isolated function init(ConnectionConfig config) returns error? {
         self.datasource = initClient(config);
     }
 
@@ -1306,7 +1306,7 @@ public isolated client class Client {
 #
 # + clientEndpointConfig - Client end point configuration
 # + return - `error` if error occurs
-isolated function initClient(ClientEndpointConfiguration clientEndpointConfig) returns handle = @java:Method {
+isolated function initClient(ConnectionConfig clientEndpointConfig) returns handle = @java:Method {
     'class: "org.ballerinalang.redis.endpoint.InitRedisClient"
 } external;
 
@@ -1781,7 +1781,7 @@ public type Options record {|
 # + password - Password for the database connection
 # + options - Properties for the connection configuration
 @display{label: "Connection Config"} 
-public type ClientEndpointConfiguration record {|
+public type ConnectionConfig record {|
     @display{label: "Host"} 
     string host = "localhost";
     @display{label: "Password"} 

--- a/redis/samples/appendString.bal
+++ b/redis/samples/appendString.bal
@@ -1,7 +1,7 @@
 import ballerinax/redis;
 import ballerina/io;
 
-redis:ClientEndpointConfiguration redisConfig = {
+redis:ConnectionConfig redisConfig = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,

--- a/redis/samples/listPushAndPop.bal
+++ b/redis/samples/listPushAndPop.bal
@@ -1,7 +1,7 @@
 import ballerinax/redis;
 import ballerina/io;
 
-redis:ClientEndpointConfiguration redisConfig = {
+redis:ConnectionConfig redisConfig = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,

--- a/redis/samples/multipleLogicalDB.bal
+++ b/redis/samples/multipleLogicalDB.bal
@@ -1,14 +1,14 @@
 import ballerinax/redis;
 import ballerina/io;
 
-redis:ClientEndpointConfiguration redisConfig1 = {
+redis:ConnectionConfig redisConfig1 = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,
         startTls: false, verifyPeer: false }
 };
 
-redis:ClientEndpointConfiguration redisConfig2 = {
+redis:ConnectionConfig redisConfig2 = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,

--- a/redis/samples/setAndGetString.bal
+++ b/redis/samples/setAndGetString.bal
@@ -1,7 +1,7 @@
 import ballerinax/redis;
 import ballerina/io;
 
-redis:ClientEndpointConfiguration redisConfig = {
+redis:ConnectionConfig redisConfig = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,

--- a/redis/samples/stringDecrement.bal
+++ b/redis/samples/stringDecrement.bal
@@ -1,7 +1,7 @@
 import ballerinax/redis;
 import ballerina/io;
 
-redis:ClientEndpointConfiguration redisConfig = {
+redis:ConnectionConfig redisConfig = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,

--- a/redis/samples/stringIncrement.bal
+++ b/redis/samples/stringIncrement.bal
@@ -1,7 +1,7 @@
 import ballerinax/redis;
 import ballerina/io;
 
-redis:ClientEndpointConfiguration redisConfig = {
+redis:ConnectionConfig redisConfig = {
     host: "localhost:6379",
     password: "",
     options: { connectionPooling: true, isClusterConnection: false, ssl: false,

--- a/redis/tests/redis.bal
+++ b/redis/tests/redis.bal
@@ -18,7 +18,7 @@ import ballerina/jballerina.java;
 import ballerina/log;
 import ballerina/test;
 
-ClientEndpointConfiguration redisConfig = {
+ConnectionConfig redisConfig = {
     host: "localhost",
     password: "",
     options: {


### PR DESCRIPTION
## Purpose
- Change connector configuration record name to `ConnectionConfig`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3
