### PR TITLE
Bump jar version to 0.99.8 same as bal package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.ballerinalang</groupId>
     <artifactId>connector-redis-parent</artifactId>
-    <version>0.99.7</version>
+    <version>0.99.8</version>
     <packaging>pom</packaging>
 
     <scm>

--- a/redis-utils/pom.xml
+++ b/redis-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>connector-redis-parent</artifactId>
         <groupId>org.ballerinalang</groupId>
-        <version>0.99.7</version>
+        <version>0.99.8</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/redis-utils/src/main/java/org/ballerinalang/redis/Constants.java
+++ b/redis-utils/src/main/java/org/ballerinalang/redis/Constants.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class Constants {
     static final int DEFAULT_REDIS_PORT = 6379;
     public static final String REDIS_EXCEPTION_OCCURRED = "{ballerinax/redis}Error";
-    public static final String REDIS_CONNECTOR_VERSION = "0.99.7";
+    public static final String REDIS_CONNECTOR_VERSION = "0.99.8";
 
     /**
      * Endpoint configuration constants.

--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -8,11 +8,11 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-redis"
 license = ["Apache-2.0"]
 
 [[platform.java11.dependency]]
-path = "../redis-utils/target/redis-0.99.7.jar"
+path = "../redis-utils/target/redis-0.99.8.jar"
 groupId = "org.ballerinalang"
 artifactId = "redis-utils"
 module = "redis-utils" 
-version="0.99.7"
+version="0.99.8"
 
 [build-options]
 taintCheck = true


### PR DESCRIPTION
# Description
Bump java component version to 0.99.8 same as ballerina package version mentioned in Ballerina.toml
 
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 