### PR TITLE
Bump ballerina lang version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,14 @@ jobs:
             - name: Maven Build
               run: mvn clean install 
             - name: Ballerina Download
-              run: sudo wget http://dist-dev.ballerina.io/downloads/swan-lake-beta6/ballerina-swan-lake-beta6.zip
+              run: sudo wget http://dist-dev.ballerina.io/downloads/2201.0.0/ballerina-2201.0.0.zip
             - name: Use Ballerina zip version
               run: sudo apt-get install -y unzip
-            - run: sudo unzip  ballerina-swan-lake-beta6.zip
+            - run: sudo unzip ballerina-2201.0.0.zip
               env: 
                   JAVA_HOME: /usr/lib/jvm/default-jvm
                   JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true 
             - name: Ballerina Build 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-swan-lake-beta6/bin/bal pack redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.0.0/bin/bal pack redis
             - name: Ballerina Test 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-swan-lake-beta6/bin/bal test redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.0.0/bin/bal test redis

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -76,17 +76,17 @@ jobs:
             - name: Maven Build
               run: mvn clean install 
             - name: Ballerina Download
-              run: sudo wget http://dist-dev.ballerina.io/downloads/swan-lake-beta6/ballerina-swan-lake-beta6.zip
+              run: sudo wget http://dist-dev.ballerina.io/downloads/2201.0.0/ballerina-2201.0.0.zip
             - name: Use Ballerina zip version
               run: sudo apt-get install -y unzip
-            - run: sudo unzip  ballerina-swan-lake-beta6.zip
+            - run: sudo unzip ballerina-2201.0.0.zip
               env: 
                   JAVA_HOME: /usr/lib/jvm/default-jvm
                   JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true 
             - name: Ballerina Build 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-swan-lake-beta6/bin/bal pack redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.0.0/bin/bal pack redis
             - name: Ballerina Test 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-swan-lake-beta6/bin/bal test redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.0.0/bin/bal test redis
 
             # Send notification when build fails
             - name: Notify failure

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -50,12 +50,12 @@ jobs:
             - name: Maven Build
               run: mvn clean install 
             - name: Ballerina Download
-              run: sudo wget http://dist-dev.ballerina.io/downloads/swan-lake-beta6/ballerina-swan-lake-beta6.zip
+              run: sudo wget http://dist-dev.ballerina.io/downloads/2201.0.0/ballerina-2201.0.0.zip
             - name: Use Ballerina zip version
               run: sudo apt-get install -y unzip
-            - run: sudo unzip  ballerina-swan-lake-beta6.zip
+            - run: sudo unzip ballerina-2201.0.0.zip
               env: 
                   JAVA_HOME: /usr/lib/jvm/default-jvm
                   JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true 
             - name: Ballerina Build 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-swan-lake-beta6/bin/bal build redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.0.0/bin/bal build redis

--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,7 @@
 
     <properties>
         <project.scm.id>my-scm-server</project.scm.id>
-        <ballerina.version>2201.0.0-20220111-211400-cfd415aa</ballerina.version>
+        <ballerina.version>2201.0.0-20220119-132800-f186f5e8</ballerina.version>
         <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>


### PR DESCRIPTION
# Description
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/262
- Bump ballerina lang version to `2201.0.0-20220119-132800-f186f5e8`
- Change download URL of ballerina