### PR TITLE
[2201.0.0] Update Netty Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>org.ballerinalang</groupId>
     <artifactId>connector-redis-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <packaging>pom</packaging>
 
     <scm>

--- a/redis-utils/pom.xml
+++ b/redis-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>connector-redis-parent</artifactId>
         <groupId>org.ballerinalang</groupId>
-        <version>2.2.0</version>
+        <version>2.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -77,8 +77,43 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.1.47.Final</version>
+            <artifactId>netty-common</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency> 
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>4.1.71.Final</version>
         </dependency>
     </dependencies>
     <build>
@@ -103,7 +138,14 @@
                                     <include>com.github.kstyrc:embedded-redis</include>
                                     <include>com.google.guava:guava</include>
                                     <include>commons-io:commons-io</include>
-                                    <include>io.netty:netty-all</include>
+                                    <include>io.netty:netty-common</include>
+                                    <include>io.netty:netty-transport</include>
+                                    <include>io.netty:netty-handler</include>
+                                    <include>io.netty:netty-transport-native-kqueue</include>
+                                    <include>io.netty:netty-transport-native-epoll</include>
+                                    <include>io.netty:netty-buffer</include>
+                                    <include>io.netty:netty-resolver</include>
+                                    <include>io.netty:netty-codec</include>
                                 </includes>
                             </artifactSet>
                         </configuration>

--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.0.0"
 org="ballerinax"
 name = "redis"
-version="2.2.0"
+version="2.2.1"
 authors = ["Ballerina"]
 keywords = ["IT Operations/Databases",  "Cost/Freemium"]
 icon = "icon.png"
@@ -10,8 +10,8 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-redis"
 license = ["Apache-2.0"]
 
 [[platform.java11.dependency]]
-path = "../redis-utils/target/redis-2.2.0.jar"
+path = "../redis-utils/target/redis-2.2.1.jar"
 groupId = "org.ballerinalang"
 artifactId = "redis-utils"
 module = "redis-utils" 
-version="2.2.0"
+version="2.2.1"

--- a/redis/Dependencies.toml
+++ b/redis/Dependencies.toml
@@ -84,7 +84,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "redis"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.runtime"},


### PR DESCRIPTION
# Description
Update the Netty Maven dependency version of the connector from `4.1.47.Final` to `4.1.71.Final`

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
