### PR TITLE
[2201.0.0] Update dependencies to fetch from Ballerina.toml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,6 +351,7 @@
 
     <modules>
         <module>redis-utils</module>
+        <module>redis</module>
     </modules>
 </project>
 

--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -15,3 +15,24 @@ groupId = "org.ballerinalang"
 artifactId = "redis-utils"
 module = "redis-utils" 
 version="2.2.1"
+
+[[platform.java11.dependency]]
+path = "./libs/lettuce-core-5.1.2.RELEASE.jar"
+
+[[platform.java11.dependency]]
+path = "./libs/netty-common-4.1.71.Final.jar"
+
+[[platform.java11.dependency]]
+path = "./libs/netty-buffer-4.1.71.Final.jar"
+
+[[platform.java11.dependency]]
+path = "./libs/netty-transport-4.1.71.Final.jar"
+
+[[platform.java11.dependency]]
+path = "./libs/netty-resolver-4.1.71.Final.jar"
+
+[[platform.java11.dependency]]
+path = "./libs/netty-handler-4.1.71.Final.jar"
+
+[[platform.java11.dependency]]
+path = "./libs/netty-codec-4.1.71.Final.jar"

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -25,25 +25,12 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>redis</artifactId>
+    <artifactId>redis1</artifactId>
     <packaging>jar</packaging>
-    <name>Ballerina - Redis Native Component</name>
+    <name>Ballerina - Redis Component</name>
     <url>http://ballerinalang.org</url>
 
     <dependencies>
-        <dependency>
-            <groupId>org.ballerinalang</groupId>
-            <artifactId>ballerina-lang</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.ballerinalang</groupId>
-            <artifactId>ballerina-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
@@ -53,17 +40,8 @@
             <artifactId>commons-pool2</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.ballerinalang</groupId>
-            <artifactId>ballerina-runtime</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.github.kstyrc</groupId>
             <artifactId>embedded-redis</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.ballerinalang</groupId>
-            <artifactId>ballerina-test-utils</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -75,28 +53,75 @@
             <artifactId>commons-io</artifactId>
             <version>2.7</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency> 
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>4.1.71.Final</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>copy-dependencies</id>
                         <phase>package</phase>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
+                            <outputDirectory>${basedir}/libs</outputDirectory>
                             <artifactSet>
                                 <includes>
                                     <include>${project.groupId}:${project.artifactId}</include>
-                                    <include>io.projectreactor:reactor-core</include>
-                                    <include>org.reactivestreams:reactive-streams</include>
-                                    <include>org.apache.commons:commons-pool2</include>
+                                    <include>io.lettuce:lettuce-core</include>
                                     <include>com.github.kstyrc:embedded-redis</include>
                                     <include>com.google.guava:guava</include>
-                                    <include>commons-io:commons-io</include>
+                                    <include>io.netty:netty-common</include>
+                                    <include>io.netty:netty-transport</include>
+                                    <include>io.netty:netty-handler</include>
+                                    <include>io.netty:netty-transport-native-kqueue</include>
+                                    <include>io.netty:netty-transport-native-epoll</include>
+                                    <include>io.netty:netty-buffer</include>
+                                    <include>io.netty:netty-resolver</include>
+                                    <include>io.netty:netty-codec</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
# Description

In the current interop implementation of Redis, the interop is JAR created as a fat jar that contains its dependencies. This is causing unnecessary conflicting jar warnings when there is another package using the same Java dependencies with even the same version being used. This is addressed by adding dependencies as platform dependencies in the Ballerina.toml

Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/286

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: 2201.0.0
* Operating System: Linux Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
