### PR TITLE
Update netty dependencies versions

### DIFF
--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-distribution = "2201.0.2"
+distribution = "2201.0.3"
 org="ballerinax"
 name = "redis"
 version="2.2.2"
@@ -20,19 +20,19 @@ version="2.2.2"
 path = "./libs/lettuce-core-5.1.2.RELEASE.jar"
 
 [[platform.java11.dependency]]
-path = "./libs/netty-common-4.1.71.Final.jar"
+path = "./libs/netty-common-4.1.77.Final.jar"
 
 [[platform.java11.dependency]]
-path = "./libs/netty-buffer-4.1.71.Final.jar"
+path = "./libs/netty-buffer-4.1.77.Final.jar"
 
 [[platform.java11.dependency]]
-path = "./libs/netty-transport-4.1.71.Final.jar"
+path = "./libs/netty-transport-4.1.77.Final.jar"
 
 [[platform.java11.dependency]]
-path = "./libs/netty-resolver-4.1.71.Final.jar"
+path = "./libs/netty-resolver-4.1.77.Final.jar"
 
 [[platform.java11.dependency]]
-path = "./libs/netty-handler-4.1.71.Final.jar"
+path = "./libs/netty-handler-4.1.77.Final.jar"
 
 [[platform.java11.dependency]]
-path = "./libs/netty-codec-4.1.71.Final.jar"
+path = "./libs/netty-codec-4.1.77.Final.jar"

--- a/redis/Dependencies.toml
+++ b/redis/Dependencies.toml
@@ -63,7 +63,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.3"
+version = "1.0.4"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/redis/pom.xml
+++ b/redis/pom.xml
@@ -56,42 +56,42 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-kqueue</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency> 
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.1.71.Final</version>
+            <version>4.1.77.Final</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
# Description
Update the Netty Maven dependency version of the connector from `4.1.71.Final` to `4.1.77.Final`
While using redis connector and http module together conflicts warnings arises. As ballerina http module recently updated its netty version for the latest due to security vulnerabilities. The relevant dependencies have been found to be in the previous version in Redis. As a current workaround netty version in Ballerina.toml is updated with the latest as in http module

Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/433

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
