### PR TITLE
Add configs needed to build GraalVM native image

### DIFF
--- a/redis-utils/src/main/resources/META-INF/native-image/org.ballerinalang/redis-utils/proxy-config.json
+++ b/redis-utils/src/main/resources/META-INF/native-image/org.ballerinalang/redis-utils/proxy-config.json
@@ -1,0 +1,14 @@
+[
+  {
+    "interfaces": [
+      "io.lettuce.core.api.sync.RedisCommands",
+      "io.lettuce.core.cluster.api.sync.RedisClusterCommands"
+    ]
+  },
+  {
+    "interfaces": [
+      "io.lettuce.core.support.ConnectionWrapping$HasTargetConnection",
+      "io.lettuce.core.api.StatefulRedisConnection"
+    ]
+  }
+]

--- a/redis-utils/src/main/resources/META-INF/native-image/org.ballerinalang/redis-utils/reflect-config.json
+++ b/redis-utils/src/main/resources/META-INF/native-image/org.ballerinalang/redis-utils/reflect-config.json
@@ -1,0 +1,4179 @@
+[
+  {
+    "name": "io.lettuce.core.AbstractRedisAsyncCommands",
+    "methods": [
+      {
+        "name": "append",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "asking",
+        "parameterTypes": []
+      },
+      {
+        "name": "auth",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "bgrewriteaof",
+        "parameterTypes": []
+      },
+      {
+        "name": "bgsave",
+        "parameterTypes": []
+      },
+      {
+        "name": "bitcount",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "bitcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "bitfield",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.BitFieldArgs"
+        ]
+      },
+      {
+        "name": "bitopAnd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "bitopNot",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "bitopOr",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "bitopXor",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "bitpos",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean"
+        ]
+      },
+      {
+        "name": "bitpos",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean",
+          "long"
+        ]
+      },
+      {
+        "name": "bitpos",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "blpop",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "brpop",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "brpoplpush",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "bzpopmax",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "bzpopmin",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "clientGetname",
+        "parameterTypes": []
+      },
+      {
+        "name": "clientKill",
+        "parameterTypes": [
+          "io.lettuce.core.KillArgs"
+        ]
+      },
+      {
+        "name": "clientKill",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clientList",
+        "parameterTypes": []
+      },
+      {
+        "name": "clientPause",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "clientSetname",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "clientUnblock",
+        "parameterTypes": [
+          "long",
+          "io.lettuce.core.UnblockType"
+        ]
+      },
+      {
+        "name": "clusterAddSlots",
+        "parameterTypes": [
+          "int[]"
+        ]
+      },
+      {
+        "name": "clusterBumpepoch",
+        "parameterTypes": []
+      },
+      {
+        "name": "clusterCountFailureReports",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterCountKeysInSlot",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "clusterDelSlots",
+        "parameterTypes": [
+          "int[]"
+        ]
+      },
+      {
+        "name": "clusterFailover",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "clusterFlushslots",
+        "parameterTypes": []
+      },
+      {
+        "name": "clusterForget",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterGetKeysInSlot",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "clusterInfo",
+        "parameterTypes": []
+      },
+      {
+        "name": "clusterKeyslot",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "clusterMeet",
+        "parameterTypes": [
+          "java.lang.String",
+          "int"
+        ]
+      },
+      {
+        "name": "clusterMyId",
+        "parameterTypes": []
+      },
+      {
+        "name": "clusterNodes",
+        "parameterTypes": []
+      },
+      {
+        "name": "clusterReplicate",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterReset",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "clusterSaveconfig",
+        "parameterTypes": []
+      },
+      {
+        "name": "clusterSetConfigEpoch",
+        "parameterTypes": [
+          "long"
+        ]
+      },
+      {
+        "name": "clusterSetSlotImporting",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterSetSlotMigrating",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterSetSlotNode",
+        "parameterTypes": [
+          "int",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterSetSlotStable",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "clusterSlaves",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "clusterSlots",
+        "parameterTypes": []
+      },
+      {
+        "name": "command",
+        "parameterTypes": []
+      },
+      {
+        "name": "commandCount",
+        "parameterTypes": []
+      },
+      {
+        "name": "commandInfo",
+        "parameterTypes": [
+          "io.lettuce.core.protocol.CommandType[]"
+        ]
+      },
+      {
+        "name": "commandInfo",
+        "parameterTypes": [
+          "java.lang.String[]"
+        ]
+      },
+      {
+        "name": "configGet",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "configResetstat",
+        "parameterTypes": []
+      },
+      {
+        "name": "configRewrite",
+        "parameterTypes": []
+      },
+      {
+        "name": "configSet",
+        "parameterTypes": [
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "dbsize",
+        "parameterTypes": []
+      },
+      {
+        "name": "debugCrashAndRecover",
+        "parameterTypes": [
+          "java.lang.Long"
+        ]
+      },
+      {
+        "name": "debugHtstats",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "debugObject",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "debugOom",
+        "parameterTypes": []
+      },
+      {
+        "name": "debugReload",
+        "parameterTypes": []
+      },
+      {
+        "name": "debugRestart",
+        "parameterTypes": [
+          "java.lang.Long"
+        ]
+      },
+      {
+        "name": "debugSdslen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "debugSegfault",
+        "parameterTypes": []
+      },
+      {
+        "name": "decr",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "decrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "del",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "digest",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "discard",
+        "parameterTypes": []
+      },
+      {
+        "name": "dispatch",
+        "parameterTypes": [
+          "io.lettuce.core.protocol.ProtocolKeyword",
+          "io.lettuce.core.output.CommandOutput"
+        ]
+      },
+      {
+        "name": "dispatch",
+        "parameterTypes": [
+          "io.lettuce.core.protocol.ProtocolKeyword",
+          "io.lettuce.core.output.CommandOutput",
+          "io.lettuce.core.protocol.CommandArgs"
+        ]
+      },
+      {
+        "name": "dump",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "echo",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "eval",
+        "parameterTypes": [
+          "java.lang.String",
+          "io.lettuce.core.ScriptOutputType",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "eval",
+        "parameterTypes": [
+          "java.lang.String",
+          "io.lettuce.core.ScriptOutputType",
+          "java.lang.Object[]",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "evalsha",
+        "parameterTypes": [
+          "java.lang.String",
+          "io.lettuce.core.ScriptOutputType",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "evalsha",
+        "parameterTypes": [
+          "java.lang.String",
+          "io.lettuce.core.ScriptOutputType",
+          "java.lang.Object[]",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "exec",
+        "parameterTypes": []
+      },
+      {
+        "name": "exists",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "expire",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "expireat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "expireat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.util.Date"
+        ]
+      },
+      {
+        "name": "flushall",
+        "parameterTypes": []
+      },
+      {
+        "name": "flushallAsync",
+        "parameterTypes": []
+      },
+      {
+        "name": "flushdb",
+        "parameterTypes": []
+      },
+      {
+        "name": "flushdbAsync",
+        "parameterTypes": []
+      },
+      {
+        "name": "geoadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "geoadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "geodist",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "java.lang.Object",
+          "io.lettuce.core.GeoArgs$Unit"
+        ]
+      },
+      {
+        "name": "geohash",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "geopos",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "georadius",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "double",
+          "io.lettuce.core.GeoArgs$Unit"
+        ]
+      },
+      {
+        "name": "georadius",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "double",
+          "io.lettuce.core.GeoArgs$Unit",
+          "io.lettuce.core.GeoArgs"
+        ]
+      },
+      {
+        "name": "georadius",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "double",
+          "io.lettuce.core.GeoArgs$Unit",
+          "io.lettuce.core.GeoRadiusStoreArgs"
+        ]
+      },
+      {
+        "name": "georadiusbymember",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "double",
+          "io.lettuce.core.GeoArgs$Unit"
+        ]
+      },
+      {
+        "name": "georadiusbymember",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "double",
+          "io.lettuce.core.GeoArgs$Unit",
+          "io.lettuce.core.GeoArgs"
+        ]
+      },
+      {
+        "name": "georadiusbymember",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "double",
+          "io.lettuce.core.GeoArgs$Unit",
+          "io.lettuce.core.GeoRadiusStoreArgs"
+        ]
+      },
+      {
+        "name": "get",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "getbit",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "getset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hdel",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "hexists",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hget",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hgetall",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hgetall",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hincrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "hincrbyfloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "double"
+        ]
+      },
+      {
+        "name": "hkeys",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hkeys",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hlen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hmget",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "hmget",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "hmset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "hscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "hset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hsetnx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hstrlen",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hvals",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hvals",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "incr",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "incrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "incrbyfloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double"
+        ]
+      },
+      {
+        "name": "info",
+        "parameterTypes": []
+      },
+      {
+        "name": "info",
+        "parameterTypes": [
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "isOpen",
+        "parameterTypes": []
+      },
+      {
+        "name": "keys",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "keys",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lastsave",
+        "parameterTypes": []
+      },
+      {
+        "name": "lindex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "linsert",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "llen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lpop",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lpush",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "lpushx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "lrange",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "lrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "lrem",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "ltrim",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "mget",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyValueStreamingChannel",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "mget",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "migrate",
+        "parameterTypes": [
+          "java.lang.String",
+          "int",
+          "int",
+          "long",
+          "io.lettuce.core.MigrateArgs"
+        ]
+      },
+      {
+        "name": "migrate",
+        "parameterTypes": [
+          "java.lang.String",
+          "int",
+          "java.lang.Object",
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "move",
+        "parameterTypes": [
+          "java.lang.Object",
+          "int"
+        ]
+      },
+      {
+        "name": "mset",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "msetnx",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "multi",
+        "parameterTypes": []
+      },
+      {
+        "name": "objectEncoding",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "objectIdletime",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "objectRefcount",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "persist",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "pexpire",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "pexpireat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "pexpireat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.util.Date"
+        ]
+      },
+      {
+        "name": "pfadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "pfcount",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "pfmerge",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "ping",
+        "parameterTypes": []
+      },
+      {
+        "name": "psetex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "pttl",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "publish",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "pubsubChannels",
+        "parameterTypes": []
+      },
+      {
+        "name": "pubsubChannels",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "pubsubNumpat",
+        "parameterTypes": []
+      },
+      {
+        "name": "pubsubNumsub",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "quit",
+        "parameterTypes": []
+      },
+      {
+        "name": "randomkey",
+        "parameterTypes": []
+      },
+      {
+        "name": "readOnly",
+        "parameterTypes": []
+      },
+      {
+        "name": "readWrite",
+        "parameterTypes": []
+      },
+      {
+        "name": "rename",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "renamenx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "reset",
+        "parameterTypes": []
+      },
+      {
+        "name": "restore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "byte[]"
+        ]
+      },
+      {
+        "name": "restore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "byte[]",
+          "io.lettuce.core.RestoreArgs"
+        ]
+      },
+      {
+        "name": "role",
+        "parameterTypes": []
+      },
+      {
+        "name": "rpop",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "rpoplpush",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "rpush",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "rpushx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "save",
+        "parameterTypes": []
+      },
+      {
+        "name": "scan",
+        "parameterTypes": []
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyStreamingChannel"
+        ]
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyStreamingChannel",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyStreamingChannel",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "scan",
+        "parameterTypes": [
+          "io.lettuce.core.output.KeyStreamingChannel",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "scard",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "scriptExists",
+        "parameterTypes": [
+          "java.lang.String[]"
+        ]
+      },
+      {
+        "name": "scriptFlush",
+        "parameterTypes": []
+      },
+      {
+        "name": "scriptKill",
+        "parameterTypes": []
+      },
+      {
+        "name": "scriptLoad",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sdiff",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sdiff",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sdiffstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "select",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "set",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "set",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "io.lettuce.core.SetArgs"
+        ]
+      },
+      {
+        "name": "setTimeout",
+        "parameterTypes": [
+          "long",
+          "java.util.concurrent.TimeUnit"
+        ]
+      },
+      {
+        "name": "setTimeout",
+        "parameterTypes": [
+          "java.time.Duration"
+        ]
+      },
+      {
+        "name": "setbit",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "int"
+        ]
+      },
+      {
+        "name": "setex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setnx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "shutdown",
+        "parameterTypes": [
+          "boolean"
+        ]
+      },
+      {
+        "name": "sinter",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sinter",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sinterstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sismember",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "slaveof",
+        "parameterTypes": [
+          "java.lang.String",
+          "int"
+        ]
+      },
+      {
+        "name": "slaveofNoOne",
+        "parameterTypes": []
+      },
+      {
+        "name": "slowlogGet",
+        "parameterTypes": []
+      },
+      {
+        "name": "slowlogGet",
+        "parameterTypes": [
+          "int"
+        ]
+      },
+      {
+        "name": "slowlogLen",
+        "parameterTypes": []
+      },
+      {
+        "name": "slowlogReset",
+        "parameterTypes": []
+      },
+      {
+        "name": "smembers",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "smembers",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "smove",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sort",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sort",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.SortArgs"
+        ]
+      },
+      {
+        "name": "sort",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sort",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.SortArgs"
+        ]
+      },
+      {
+        "name": "sortStore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.SortArgs",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "spop",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "spop",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "srandmember",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "srandmember",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "srandmember",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "srem",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "sscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "strlen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sunion",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sunion",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sunionstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "swapdb",
+        "parameterTypes": [
+          "int",
+          "int"
+        ]
+      },
+      {
+        "name": "time",
+        "parameterTypes": []
+      },
+      {
+        "name": "touch",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "ttl",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "type",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "unlink",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "unwatch",
+        "parameterTypes": []
+      },
+      {
+        "name": "waitForReplication",
+        "parameterTypes": [
+          "int",
+          "long"
+        ]
+      },
+      {
+        "name": "watch",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "xack",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "java.lang.String[]"
+        ]
+      },
+      {
+        "name": "xadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.XAddArgs",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "xadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.XAddArgs",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "xadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "xadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "xclaim",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Consumer",
+          "long",
+          "java.lang.String[]"
+        ]
+      },
+      {
+        "name": "xclaim",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Consumer",
+          "io.lettuce.core.XClaimArgs",
+          "java.lang.String[]"
+        ]
+      },
+      {
+        "name": "xdel",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String[]"
+        ]
+      },
+      {
+        "name": "xgroupCreate",
+        "parameterTypes": [
+          "io.lettuce.core.XReadArgs$StreamOffset",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "xgroupDelconsumer",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Consumer"
+        ]
+      },
+      {
+        "name": "xgroupDestroy",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "xgroupSetid",
+        "parameterTypes": [
+          "io.lettuce.core.XReadArgs$StreamOffset",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "xlen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "xpending",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Consumer",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "xpending",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "xpending",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "xrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "xrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "xread",
+        "parameterTypes": [
+          "io.lettuce.core.XReadArgs",
+          "io.lettuce.core.XReadArgs$StreamOffset[]"
+        ]
+      },
+      {
+        "name": "xread",
+        "parameterTypes": [
+          "io.lettuce.core.XReadArgs$StreamOffset[]"
+        ]
+      },
+      {
+        "name": "xreadgroup",
+        "parameterTypes": [
+          "io.lettuce.core.Consumer",
+          "io.lettuce.core.XReadArgs",
+          "io.lettuce.core.XReadArgs$StreamOffset[]"
+        ]
+      },
+      {
+        "name": "xreadgroup",
+        "parameterTypes": [
+          "io.lettuce.core.Consumer",
+          "io.lettuce.core.XReadArgs$StreamOffset[]"
+        ]
+      },
+      {
+        "name": "xrevrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "xrevrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "xtrim",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "xtrim",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean",
+          "long"
+        ]
+      },
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ZAddArgs",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ZAddArgs",
+          "io.lettuce.core.ScoredValue[]"
+        ]
+      },
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ZAddArgs",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScoredValue[]"
+        ]
+      },
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zaddincr",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zaddincr",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ZAddArgs",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zcard",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zincrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zinterstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ZStoreArgs",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zinterstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zlexcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zlexcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zpopmax",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zpopmax",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "zpopmin",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zpopmin",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "zrange",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangeWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangeWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrank",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zrem",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zremrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zremrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zremrangebyrank",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zremrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zremrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zremrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrevrange",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangeWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangeWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "io.lettuce.core.output.ValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrevrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "double",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range",
+          "io.lettuce.core.Limit"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String"
+        ]
+      },
+      {
+        "name": "zrevrangebyscoreWithScores",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.String",
+          "java.lang.String",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrank",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "io.lettuce.core.output.ScoredValueStreamingChannel",
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor"
+        ]
+      },
+      {
+        "name": "zscan",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScanCursor",
+          "io.lettuce.core.ScanArgs"
+        ]
+      },
+      {
+        "name": "zscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zunionstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ZStoreArgs",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zunionstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.ChannelGroupListener",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.ConnectionEventTrigger",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.PlainChannelInitializer"
+  },
+  {
+    "name": "io.lettuce.core.PlainChannelInitializer$1",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.RedisAsyncCommandsImpl",
+    "methods": [
+      {
+        "name": "getStatefulConnection",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.StatefulRedisConnection",
+    "methods": [
+      {
+        "name": "sync",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.BaseRedisCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "echo",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "ping",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisGeoCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisHLLCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisHashCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "hdel",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "hexists",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hget",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hgetall",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hincrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "hincrbyfloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "double"
+        ]
+      },
+      {
+        "name": "hkeys",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hlen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hmget",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "hmset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "hset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hstrlen",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "hvals",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisKeyCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "del",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "exists",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "expire",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "keys",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "move",
+        "parameterTypes": [
+          "java.lang.Object",
+          "int"
+        ]
+      },
+      {
+        "name": "persist",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "pexpire",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "pttl",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "randomkey",
+        "parameterTypes": []
+      },
+      {
+        "name": "rename",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "renamenx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "sort",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "type",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisListCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "blpop",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "brpop",
+        "parameterTypes": [
+          "long",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "lindex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "linsert",
+        "parameterTypes": [
+          "java.lang.Object",
+          "boolean",
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "llen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lpop",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lpush",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "lpushx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "lrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "lrem",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "lset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "ltrim",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "rpop",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "rpoplpush",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "rpush",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisScriptingCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisServerCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisSetCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "sadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sdiff",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sdiffstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sinter",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sinterstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sismember",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "smembers",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "spop",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "srem",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sunion",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "sunionstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisSortedSetCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "zadd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.ScoredValue[]"
+        ]
+      },
+      {
+        "name": "zcard",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zincrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zinterstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zlexcount",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrank",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zrem",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "zremrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zremrangebyrank",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zremrangebyscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "zrevrangebylex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "io.lettuce.core.Range"
+        ]
+      },
+      {
+        "name": "zrevrank",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zscore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "zunionstore",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisStreamCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisStringCommands",
+    "queryAllDeclaredMethods": true,
+    "methods": [
+      {
+        "name": "append",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "bitcount",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "bitopAnd",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "bitopNot",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "bitopOr",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "bitopXor",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "decr",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "decrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "get",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "getbit",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "getrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "long"
+        ]
+      },
+      {
+        "name": "getset",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "incr",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "incrby",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long"
+        ]
+      },
+      {
+        "name": "incrbyfloat",
+        "parameterTypes": [
+          "java.lang.Object",
+          "double"
+        ]
+      },
+      {
+        "name": "mget",
+        "parameterTypes": [
+          "java.lang.Object[]"
+        ]
+      },
+      {
+        "name": "mset",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "msetnx",
+        "parameterTypes": [
+          "java.util.Map"
+        ]
+      },
+      {
+        "name": "psetex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "set",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setbit",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "int"
+        ]
+      },
+      {
+        "name": "setex",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setnx",
+        "parameterTypes": [
+          "java.lang.Object",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "setrange",
+        "parameterTypes": [
+          "java.lang.Object",
+          "long",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "strlen",
+        "parameterTypes": [
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.api.sync.RedisTransactionalCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.cluster.api.sync.RedisClusterCommands",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.lettuce.core.protocol.CommandEncoder"
+  },
+  {
+    "name": "io.lettuce.core.protocol.CommandHandler",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "write",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object",
+          "io.netty.channel.ChannelPromise"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.protocol.ConnectionWatchdog",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.lettuce.core.support.ConnectionPoolSupport$1",
+    "queryAllPublicConstructors": true
+  },
+  {
+    "name": "io.netty.buffer.AbstractByteBufAllocator",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.netty.buffer.AbstractReferenceCountedByteBuf",
+    "fields": [
+      {
+        "name": "refCnt"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.ChannelDuplexHandler",
+    "methods": [
+      {
+        "name": "bind",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "close",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "connect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "deregister",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "disconnect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "flush",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "read",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "write",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object",
+          "io.netty.channel.ChannelPromise"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.ChannelHandlerAdapter",
+    "methods": [
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.ChannelInboundHandlerAdapter",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.ChannelInitializer",
+    "methods": [
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.ChannelOutboundHandlerAdapter",
+    "methods": [
+      {
+        "name": "bind",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "close",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "connect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "deregister",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "disconnect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "flush",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "read",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.DefaultChannelPipeline$HeadContext",
+    "methods": [
+      {
+        "name": "bind",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "close",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "connect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.net.SocketAddress",
+          "java.net.SocketAddress",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "deregister",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "disconnect",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "io.netty.channel.ChannelPromise"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      },
+      {
+        "name": "flush",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "read",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "write",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object",
+          "io.netty.channel.ChannelPromise"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.DefaultChannelPipeline$TailContext",
+    "methods": [
+      {
+        "name": "channelActive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelInactive",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRead",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      },
+      {
+        "name": "channelReadComplete",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelRegistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelUnregistered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "channelWritabilityChanged",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext"
+        ]
+      },
+      {
+        "name": "exceptionCaught",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Throwable"
+        ]
+      },
+      {
+        "name": "userEventTriggered",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.channel.socket.nio.NioSocketChannel",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "io.netty.handler.codec.MessageToByteEncoder",
+    "methods": [
+      {
+        "name": "write",
+        "parameterTypes": [
+          "io.netty.channel.ChannelHandlerContext",
+          "java.lang.Object",
+          "io.netty.channel.ChannelPromise"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "io.netty.util.ReferenceCountUtil",
+    "queryAllDeclaredMethods": true
+  },
+  {
+    "name": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueColdProducerFields",
+    "fields": [
+      {
+        "name": "producerLimit"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueConsumerFields",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.util.internal.shaded.org.jctools.queues.BaseMpscLinkedArrayQueueProducerFields",
+    "fields": [
+      {
+        "name": "producerIndex"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueConsumerIndexField",
+    "fields": [
+      {
+        "name": "consumerIndex"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerIndexField",
+    "fields": [
+      {
+        "name": "producerIndex"
+      }
+    ]
+  },
+  {
+    "name": "io.netty.util.internal.shaded.org.jctools.queues.MpscArrayQueueProducerLimitField",
+    "fields": [
+      {
+        "name": "producerLimit"
+      }
+    ]
+  },
+  {
+    "name": "org.HdrHistogram.Histogram"
+  },
+  {
+    "name": "org.apache.commons.pool2.impl.DefaultEvictionPolicy",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": []
+      }
+    ]
+  },
+  {
+    "name": "org.apache.commons.pool2.impl.DefaultPooledObjectInfo",
+    "queryAllPublicMethods": true
+  },
+  {
+    "name": "org.apache.commons.pool2.impl.GenericObjectPoolMXBean",
+    "queryAllPublicMethods": true
+  }
+]


### PR DESCRIPTION
# Description

With Ballerina 3.x.x native image support based on GraalVM is introduced. 
This PR contains config files required to build the native image. 

With Ballerina 3.x.x image can be built using 
```
bal build --native
```

Fixes https://github.com/wso2-enterprise/choreo/issues/16729

One line release note: 
- Add GraalVM support 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Setup Redis externally and run tests against it. To cleanup Redis DB at each run use `redis-cli flushall` and `redis-cli -n 2 flushdb`


**Test Configuration**:
* Ballerina Version: 3.0.0 RC
* Operating System: Mac OS AMD 64 arch
* Java SDK: graalvm-ce-java11-22.3.0

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
