### PR TITLE
Update ballerina lang version to 2201.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,17 +73,17 @@ jobs:
             - name: Maven Build
               run: mvn clean install 
             - name: Ballerina Download
-              run: sudo wget https://dist.ballerina.io/downloads/2201.2.1/ballerina-2201.2.1-swan-lake.zip
+              run: sudo wget https://dist.ballerina.io/downloads/2201.2.3/ballerina-2201.2.3-swan-lake.zip
             - name: Use Ballerina zip version
               run: sudo apt-get install -y unzip
-            - run: sudo unzip ballerina-2201.2.1-swan-lake.zip
+            - run: sudo unzip ballerina-2201.2.3-swan-lake.zip
               env: 
                   JAVA_HOME: /usr/lib/jvm/default-jvm
                   JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true 
             - name: Ballerina Build 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.1-swan-lake/bin/bal pack redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.3-swan-lake/bin/bal pack redis
             - name: Ballerina Test 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.1-swan-lake/bin/bal test --code-coverage redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.3-swan-lake/bin/bal test --code-coverage redis
 
             # Read the ballerina test results
             - name: Read Ballerina Test Results

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -76,17 +76,17 @@ jobs:
             - name: Maven Build
               run: mvn clean install 
             - name: Ballerina Download
-              run: sudo wget https://dist.ballerina.io/downloads/2201.2.1/ballerina-2201.2.1-swan-lake.zip
+              run: sudo wget https://dist.ballerina.io/downloads/2201.2.3/ballerina-2201.2.3-swan-lake.zip
             - name: Use Ballerina zip version
               run: sudo apt-get install -y unzip
-            - run: sudo unzip ballerina-2201.2.1-swan-lake.zip
+            - run: sudo unzip ballerina-2201.2.3-swan-lake.zip
               env: 
                   JAVA_HOME: /usr/lib/jvm/default-jvm
                   JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true 
             - name: Ballerina Build 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.1-swan-lake/bin/bal pack redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.3-swan-lake/bin/bal pack redis
             - name: Ballerina Test 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.1-swan-lake/bin/bal test --code-coverage redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.3-swan-lake/bin/bal test --code-coverage redis
 
             # Read the ballerina test results
             - name: Read Ballerina Test Results

--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -84,7 +84,7 @@ jobs:
         - name: Maven Build
           run: mvn clean install 
         - name: Ballerina Build
-          uses: ballerina-platform/ballerina-action@2201.2.1
+          uses: ballerina-platform/ballerina-action@2201.2.3
           with:
             args:
               pack redis
@@ -94,7 +94,7 @@ jobs:
 
         - name: Push to Staging
           if: github.event.inputs.bal_central_environment == 'STAGE'
-          uses: ballerina-platform/ballerina-action@2201.2.1
+          uses: ballerina-platform/ballerina-action@2201.2.3
           with:
             args: 
               push
@@ -105,7 +105,7 @@ jobs:
         
         - name: Push to Dev
           if: github.event.inputs.bal_central_environment == 'DEV'
-          uses: ballerina-platform/ballerina-action@2201.2.1
+          uses: ballerina-platform/ballerina-action@2201.2.3
           with:
             args: 
               push

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -50,12 +50,12 @@ jobs:
             - name: Maven Build
               run: mvn clean install 
             - name: Ballerina Download
-              run: sudo wget https://dist.ballerina.io/downloads/2201.2.1/ballerina-2201.2.1-swan-lake.zip
+              run: sudo wget https://dist.ballerina.io/downloads/2201.2.3/ballerina-2201.2.3-swan-lake.zip
             - name: Use Ballerina zip version
               run: sudo apt-get install -y unzip
-            - run: sudo unzip ballerina-2201.2.1-swan-lake.zip
+            - run: sudo unzip ballerina-2201.2.3-swan-lake.zip
               env: 
                   JAVA_HOME: /usr/lib/jvm/default-jvm
                   JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true 
             - name: Ballerina Build 
-              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.1-swan-lake/bin/bal build redis
+              run: /home/runner/work/module-ballerinax-redis/module-ballerinax-redis/ballerina-2201.2.3-swan-lake/bin/bal build redis

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         - name: Maven Build
           run: mvn clean install 
         - name: Ballerina Build
-          uses: ballerina-platform/ballerina-action@2201.2.1
+          uses: ballerina-platform/ballerina-action@2201.2.3
           with:
             args:
               pack redis
@@ -85,7 +85,7 @@ jobs:
             JAVA_HOME: /usr/lib/jvm/default-jvm 
             JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
         - name: Ballerina Push
-          uses: ballerina-platform/ballerina-action@2201.2.1
+          uses: ballerina-platform/ballerina-action@2201.2.3
           with:
             args: 
               push

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
 
     <properties>
         <project.scm.id>my-scm-server</project.scm.id>
-        <ballerina.version>2201.2.1</ballerina.version>
+        <ballerina.version>2201.2.3</ballerina.version>
         <mvn.processor.plugin.version>2.2.4</mvn.processor.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>

--- a/redis/Dependencies.toml
+++ b/redis/Dependencies.toml
@@ -63,7 +63,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}

--- a/redis/Package.md
+++ b/redis/Package.md
@@ -9,7 +9,7 @@ This package provides the capability to access Redis and it provides the functio
 ### Compatibility
 |                     | Version            |
 |---------------------|--------------------|
-| Ballerina Language  | Swan Lake 2201.2.1 |
+| Ballerina Language  | Swan Lake 2201.2.3 |
 
 ## Report issues
 To report bugs, request new features, start new discussions, view project boards, etc., go to the [Ballerina Extended Library repository](https://github.com/ballerina-platform/ballerina-extended-library)


### PR DESCRIPTION
# Description

Update Ballerina version connector uses to 2201.2.3

One line release note: 
-  Update Ballerina version connector uses underneath to 2201.2.3

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
