### PR TITLE
Fix invalid path to test resources

### DIFF
--- a/redis-utils/src/main/java/org/ballerinalang/redis/utils/RedisDbUtils.java
+++ b/redis-utils/src/main/java/org/ballerinalang/redis/utils/RedisDbUtils.java
@@ -114,10 +114,10 @@ public class RedisDbUtils {
 
     private static Path getResourcePath() {
         Path userDir = Paths.get(System.getProperty("user.dir"));
-        if (userDir.toString().endsWith(File.separator + "redis")) {
-            return userDir.resolve("tests").resolve("resources");
+        if (!userDir.toString().endsWith(File.separator + "redis")) {
+            userDir = userDir.resolve("redis");
         }
-        return userDir.resolve("redis/tests").resolve("resources");
+        return userDir.resolve("tests").resolve("resources");
     }
 
     /**

--- a/redis-utils/src/main/java/org/ballerinalang/redis/utils/RedisDbUtils.java
+++ b/redis-utils/src/main/java/org/ballerinalang/redis/utils/RedisDbUtils.java
@@ -32,9 +32,11 @@ import org.ballerinalang.redis.utils.ModuleUtils;
 import redis.embedded.RedisServer;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,8 +58,7 @@ public class RedisDbUtils {
      * @throws IOException exception
      */
     public static Object initServer() throws IOException {
-        String scriptPath = Paths.get(System.getProperty("user.dir")).
-                resolve("redis/tests").resolve("resources").resolve("setup.sh").toString();
+        String scriptPath = getResourcePath().resolve("setup.sh").toString();
         ProcessBuilder processBuilder = new ProcessBuilder();
         processBuilder.command("bash", scriptPath);
         Process process = processBuilder.start();
@@ -89,8 +90,7 @@ public class RedisDbUtils {
      */
     public static Object stopServer() throws IOException {
         redisServer.stop();
-        String scriptPath = Paths.get(System.getProperty("user.dir")).
-                resolve("redis/tests").resolve("resources").resolve("cleanup.sh").toString();
+        String scriptPath = getResourcePath().resolve("cleanup.sh").toString();
         ProcessBuilder processBuilder = new ProcessBuilder();
         processBuilder.command("bash", scriptPath);
         Process process = processBuilder.start();
@@ -110,6 +110,14 @@ public class RedisDbUtils {
         }
         process.destroy();
         return "OK";
+    }
+
+    private static Path getResourcePath() {
+        Path userDir = Paths.get(System.getProperty("user.dir"));
+        if (userDir.toString().endsWith(File.separator + "redis")) {
+            return userDir.resolve("tests").resolve("resources");
+        }
+        return userDir.resolve("redis/tests").resolve("resources");
     }
 
     /**


### PR DESCRIPTION
# Description

Tests were failing when the tests are triggered outside the `redis` directory, This PR fixed the issue, so that if the test is ran either within `redis` dir or outside, the path for test resources will be retrieved correctly

Fixes # (issue)

Related Pull Requests (remove if not relevant)
- Pull request 1
- Pull request 2

One line release note: 
- One line describing the feature/improvement/fix made by this PR 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
