### PR TITLE
Bump netty version to 4.1.94.Final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
                 ./gradlew build
 
             - name: Set Up Ballerina
-                uses: ballerina-platform/setup-ballerina@v1.1.0
-                with:
-                  version: latest
+              uses: ballerina-platform/setup-ballerina@v1.1.0
+              with:
+                version: latest
 
             - name: Ballerina Build
               working-directory: ./redis

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -29,9 +29,9 @@ jobs:
                 ./gradlew build
 
             - name: Set Up Ballerina
-                uses: ballerina-platform/setup-ballerina@v1.1.0
-                with:
-                  version: latest
+              uses: ballerina-platform/setup-ballerina@v1.1.0
+              with:
+                version: latest
 
             - name: Ballerina Build
               working-directory: ./redis

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,9 +26,9 @@ jobs:
                 ./gradlew build
 
             - name: Set Up Ballerina
-                uses: ballerina-platform/setup-ballerina@v1.1.0
-                with:
-                  version: latest
+              uses: ballerina-platform/setup-ballerina@v1.1.0
+              with:
+                version: latest
 
             - name: Ballerina Build
               working-directory: ./redis

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.ballerinalang.redis
-version=2.5.0
+version=2.5.1
 ballerinaLangVersion=2201.7.0
 
 downloadPluginVersion=4.0.4

--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -44,42 +44,42 @@ version = "2.7"
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-kqueue"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-epoll"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.86.Final"
+version = "4.1.94.Final"
 
 [[platform.java11.dependency]]
 groupId = "io.projectreactor"

--- a/redis/Ballerina.toml
+++ b/redis/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.7.0"
 org="ballerinax"
 name = "redis"
-version="2.5.0"
+version="2.5.1"
 authors = ["Ballerina"]
 keywords = ["IT Operations/Databases",  "Cost/Freemium"]
 icon = "icon.png"
@@ -10,11 +10,11 @@ repository = "https://github.com/ballerina-platform/module-ballerinax-redis"
 license = ["Apache-2.0"]
 
 [[platform.java11.dependency]]
-path = "../redis-utils/build/libs/redis-utils-2.5.0.jar"
+path = "../redis-utils/build/libs/redis-utils-2.5.1.jar"
 groupId = "org.ballerinalang"
 artifactId = "redis-utils"
 module = "redis-utils" 
-version="2.5.0"
+version="2.5.1"
 
 [[platform.java11.dependency]]
 groupId = "io.lettuce"


### PR DESCRIPTION
# Description
- Bump netty version to `4.1.94.Final`
- Bump connector version to 2.5.1
- Fix issues in workflow files

# Related Issue
- https://github.com/wso2-enterprise/choreo/issues/22846