### PR TITLE
Add support for Redis 7.x.x versions

### DIFF
--- a/ballerina/tests/resources/docker/docker-compose.yml
+++ b/ballerina/tests/resources/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.0'
 
 services:
-  redis-no-ssl:
-    image: redis:5.0.7
+  redis-standalone:
+    image: redis:7.0.0
     ports:
-      - "6379:6379"
+      - '6379:6379'

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,11 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.2.0
 
-lettuceCoreVersion=5.1.2.RELEASE
+lettuceCoreVersion=6.3.1.RELEASE
 commonsPool2Version=2.11.1
 
 guavaVersion=32.0.0-jre
 commonsIoVersion=2.7
 nettyVersion=4.1.94.Final
-reactorCoreVersion=3.2.2.RELEASE
+reactorCoreVersion=3.6.2
 reactiveStreamsVersion=1.0.2

--- a/native/src/main/java/org/ballerinalang/redis/connection/RedisConnectionManager.java
+++ b/native/src/main/java/org/ballerinalang/redis/connection/RedisConnectionManager.java
@@ -352,7 +352,7 @@ public class RedisConnectionManager<K, V> {
         }
     }
 
-    private Object getCommandConnection() throws RedisConnectorException {
+    private BaseRedisCommands<K, V> getCommandConnection() throws RedisConnectorException {
         if (isClusterConnection()) {
             return getRedisClusterCommands();
         } else {

--- a/native/src/main/java/org/ballerinalang/redis/connection/RedisKeyCommandExecutor.java
+++ b/native/src/main/java/org/ballerinalang/redis/connection/RedisKeyCommandExecutor.java
@@ -156,7 +156,7 @@ public class RedisKeyCommandExecutor {
         }
     }
 
-    public <K> String randomKey() throws RedisConnectorException {
+    public <K> K randomKey() throws RedisConnectorException {
         RedisKeyCommands<K, String> keyCommands = null;
         try {
             keyCommands = (RedisKeyCommands<K, String>) connManager.getKeyCommandConnection();


### PR DESCRIPTION
## Purpose
This PR adds support for the latest Redis server 7.x.x versions.

Resolves #https://github.com/ballerina-platform/ballerina-library/issues/5953

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
