### PR TITLE
Move to independent graalVM check workflow

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -4,14 +4,65 @@ on:
   schedule:
     - cron: "30 18 * * *"
   workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, labeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: graalvm-check
   cancel-in-progress: true
 
 jobs:
-  call_workflow_template:
-    name: Run Workflow Template
-    if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-    uses: ballerina-platform/ballerina-standard-library/.github/workflows/build-with-bal-test-graalvm-connector-template.yml@main
-    secrets: inherit
+  build:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'Skip GraalVM Check')
+
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+
+      - name: Set Up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
+      - name: Set up GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "17"
+          distribution: "graalvm-community"
+          set-java-home: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check GraalVM installation
+        run: |
+          echo "GRAALVM_HOME: ${{ env.GRAALVM_HOME }}"
+          echo "JAVA_HOME: ${{ env.JAVA_HOME }}"
+          native-image --version
+
+      - name: Set ENV Variables
+        run: |
+          echo -e '${{ toJson(secrets) }}' | jq -r 'to_entries[] | .key + "=" + .value' >> $GITHUB_ENV
+
+      - name: Build Package
+        run: ./gradlew build
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove Target Directory
+        run: sudo rm -rf ballerina/target
+
+      - name: Start Redis Server
+        run: |
+          cd ballerina/tests/resources/docker
+          docker-compose -f docker-compose-standalone.yml up -d 
+
+      - name: Test with GraalVM
+        run: |
+          cd ballerina
+          bal test --graalvm
+
+      - name: Stop Redis Server
+        run: |
+          cd ballerina/tests/resources/docker
+          docker-compose -f docker-compose-standalone.yml down


### PR DESCRIPTION
## Purpose
This is because the GraalVM check for Redis is failing due to the Redis server (runs on docker-compose) is not getting started during the GraalVM workflow run. This independent workflow adds an additional step to run the docker-compose before running the tests. 

This can be reverted back to the centralized workflows, once we support graalVM based Ballerina docker images (so that we can use gradle build for the graalVM workflow as well)


## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
