### PR TITLE
Fix quickstart code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Create a `redis:ConnectionConfig` instance by giving the Redis server configurat
 initialize the Ballerina Redis client using it.
 
 ```ballerina
-redis:Client redis = new (
+redis:Client redis = check new (
     connection = {
         host: "localhost",
         port: 6379

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -65,7 +65,7 @@ Create a `redis:ConnectionConfig` instance by giving the Redis server configurat
 initialize the Ballerina Redis client using it.
 
 ```ballerina
-redis:Client redis = new (
+redis:Client redis = check new (
     connection = {
         host: "localhost",
         port: 6379

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -65,7 +65,7 @@ Create a `redis:ConnectionConfig` instance by giving the Redis server configurat
 initialize the Ballerina Redis client using it.
 
 ```ballerina
-redis:Client redis = new (
+redis:Client redis = check new (
     connection = {
         host: "localhost",
         port: 6379


### PR DESCRIPTION
## Purpose
$subject fixes a syntax error in the Ballerina quickstart code sample in the docs.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
