### PR TITLE
Bump the netty version

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,3 +3,8 @@ CVE-2023-4586
 
 # False positive
 CVE-2021-29469
+
+# False positive: GHSA-rwm7-x88c-3g2p advisory text states only netty 4.2.x
+# (up to 4.2.12.Final) is affected; the 4.1.x branch does not contain the
+# vulnerable epoll half-close code path.
+CVE-2026-42577

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -44,56 +44,56 @@ path = "./lib/commons-io-2.14.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.125.Final"
-path = "./lib/netty-common-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-common-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.125.Final"
-path = "./lib/netty-buffer-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-buffer-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.125.Final"
-path = "./lib/netty-transport-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.125.Final"
-path = "./lib/netty-resolver-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-resolver-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.125.Final"
-path = "./lib/netty-handler-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-handler-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-kqueue"
-version = "4.1.125.Final"
-path = "./lib/netty-transport-native-kqueue-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-native-kqueue-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-epoll"
-version = "4.1.125.Final"
-path = "./lib/netty-transport-native-epoll-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-native-epoll-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.125.Final"
-path = "./lib/netty-codec-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-codec-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.125.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.125.Final.jar"
+version = "4.1.133.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.133.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.projectreactor"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ commonsPool2Version=2.11.1
 
 guavaVersion=32.0.0-jre
 commonsIoVersion=2.14.0
-nettyVersion=4.1.125.Final
+nettyVersion=4.1.133.Final
 reactorCoreVersion=3.6.2
 reactiveStreamsVersion=1.0.2


### PR DESCRIPTION
Bump the netty version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the Netty dependency version from 4.1.125.Final to 4.1.133.Final across the project. The changes improve stability and address maintenance concerns by upgrading this core networking library.

## Changes

- **gradle.properties**: Updated the `nettyVersion` property to `4.1.133.Final`
- **ballerina/Ballerina.toml**: Bumped all `io.netty` artifacts to version `4.1.133.Final`, including netty-common, netty-buffer, netty-transport, netty-resolver, netty-handler, netty-codec, and platform-specific artifacts (kqueue, epoll, unix-common)
- **.trivyignore**: Updated the configuration file to reflect advisories relevant to the dependency update

All changes are focused on dependency version management with no impact to the public API or exported entities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-redis/pull/260)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->