### PR TITLE
Add flushDb and flushAll remote functions to the Redis client

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -1349,17 +1349,17 @@ public isolated client class Client {
 
     # Remove all the keys from the currently selected database.
     #
-    # + return - String with the value `OK` if the operation was successful or `redis:Error` if an error occurs
+    # + return - `nil` if the operation was successful or an `redis:Error` if an error occurs
     @display {label: "Flush Database"}
-    isolated remote function flushDb() returns @display {label: "Result"} string|Error = @java:Method {
+    isolated remote function flushDb() returns Error? = @java:Method {
         'class: "io.ballerina.lib.redis.ConnectionCommands"
     } external;
 
     # Remove all the keys from all the databases.
     #
-    # + return - String with the value `OK` if the operation was successful or `redis:Error` if an error occurs
+    # + return - `nil` if the operation was successful or an `redis:Error` if an error occurs
     @display {label: "Flush All Databases"}
-    isolated remote function flushAll() returns @display {label: "Result"} string|Error = @java:Method {
+    isolated remote function flushAll() returns Error? = @java:Method {
         'class: "io.ballerina.lib.redis.ConnectionCommands"
     } external;
 

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -1347,6 +1347,22 @@ public isolated client class Client {
         'class: "io.ballerina.lib.redis.ConnectionCommands"
     } external;
 
+    # Remove all the keys from the currently selected database.
+    #
+    # + return - String with the value `OK` if the operation was successful or `redis:Error` if an error occurs
+    @display {label: "Flush Database"}
+    isolated remote function flushDb() returns @display {label: "Result"} string|Error = @java:Method {
+        'class: "io.ballerina.lib.redis.ConnectionCommands"
+    } external;
+
+    # Remove all the keys from all the databases.
+    #
+    # + return - String with the value `OK` if the operation was successful or `redis:Error` if an error occurs
+    @display {label: "Flush All Databases"}
+    isolated remote function flushAll() returns @display {label: "Result"} string|Error = @java:Method {
+        'class: "io.ballerina.lib.redis.ConnectionCommands"
+    } external;
+
     # Close the connection.
     #
     # + return - `nil` if the operation was successful or an `redis:Error` if an error occurs

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -1349,17 +1349,17 @@ public isolated client class Client {
 
     # Remove all the keys from the currently selected database.
     #
-    # + return - `nil` if the operation was successful or an `redis:Error` if an error occurs
+    # + return - String with the value `OK` if the operation was successful or `redis:Error` if an error occurs
     @display {label: "Flush Database"}
-    isolated remote function flushDb() returns Error? = @java:Method {
+    isolated remote function flushDb() returns @display {label: "Result"} string|Error = @java:Method {
         'class: "io.ballerina.lib.redis.ConnectionCommands"
     } external;
 
     # Remove all the keys from all the databases.
     #
-    # + return - `nil` if the operation was successful or an `redis:Error` if an error occurs
+    # + return - String with the value `OK` if the operation was successful or `redis:Error` if an error occurs
     @display {label: "Flush All Databases"}
-    isolated remote function flushAll() returns Error? = @java:Method {
+    isolated remote function flushAll() returns @display {label: "Result"} string|Error = @java:Method {
         'class: "io.ballerina.lib.redis.ConnectionCommands"
     } external;
 

--- a/ballerina/tests/connection_command_tests.bal
+++ b/ballerina/tests/connection_command_tests.bal
@@ -32,7 +32,9 @@ function testEcho() returns error? {
 }
 
 // `flushDb` is run against a dedicated database index (not the shared `redis` client's database) so that the
-// fixture data set up in `init.bal` and relied on by the rest of the test suite is not wiped out.
+// fixture data set up in `init.bal` and relied on by the rest of the test suite is not wiped out. A key is also
+// set on the shared `redis` client's (default) database to verify that `flushDb` only clears the selected
+// database and leaves other databases untouched.
 
 @test:Config {
     groups: ["standalone"]
@@ -47,11 +49,19 @@ function testFlushDb() returns error? {
     string setResult = check flushDbClient->set("testFlushDbKey", "testFlushDbValue");
     test:assertEquals(setResult, "OK");
 
-    string flushResult = check flushDbClient->flushDb();
-    test:assertEquals(flushResult, "OK");
+    string setOtherDbResult = check redis->set("testFlushDbIsolationKey", "testFlushDbIsolationValue");
+    test:assertEquals(setOtherDbResult, "OK");
+
+    check flushDbClient->flushDb();
 
     int existsResult = check flushDbClient->exists(["testFlushDbKey"]);
     test:assertEquals(existsResult, 0);
+
+    int otherDbExistsResult = check redis->exists(["testFlushDbIsolationKey"]);
+    test:assertEquals(otherDbExistsResult, 1);
+
+    int deleteResult = check redis->del(["testFlushDbIsolationKey"]);
+    test:assertEquals(deleteResult, 1);
 
     check flushDbClient.close();
 }
@@ -76,8 +86,7 @@ function testFlushAll() returns error? {
     string setResult = check flushAllClient->set("testFlushAllKey", "testFlushAllValue");
     test:assertEquals(setResult, "OK");
 
-    string flushResult = check flushAllClient->flushAll();
-    test:assertEquals(flushResult, "OK");
+    check flushAllClient->flushAll();
 
     int existsResult = check flushAllClient->exists(["testFlushAllKey"]);
     test:assertEquals(existsResult, 0);

--- a/ballerina/tests/connection_command_tests.bal
+++ b/ballerina/tests/connection_command_tests.bal
@@ -52,7 +52,8 @@ function testFlushDb() returns error? {
     string setOtherDbResult = check redis->set("testFlushDbIsolationKey", "testFlushDbIsolationValue");
     test:assertEquals(setOtherDbResult, "OK");
 
-    check flushDbClient->flushDb();
+    string flushResult = check flushDbClient->flushDb();
+    test:assertEquals(flushResult, "OK");
 
     int existsResult = check flushDbClient->exists(["testFlushDbKey"]);
     test:assertEquals(existsResult, 0);
@@ -86,7 +87,8 @@ function testFlushAll() returns error? {
     string setResult = check flushAllClient->set("testFlushAllKey", "testFlushAllValue");
     test:assertEquals(setResult, "OK");
 
-    check flushAllClient->flushAll();
+    string flushResult = check flushAllClient->flushAll();
+    test:assertEquals(flushResult, "OK");
 
     int existsResult = check flushAllClient->exists(["testFlushAllKey"]);
     test:assertEquals(existsResult, 0);

--- a/ballerina/tests/connection_command_tests.bal
+++ b/ballerina/tests/connection_command_tests.bal
@@ -30,3 +30,57 @@ function testEcho() returns error? {
     string result = check redis->echo("Hello");
     test:assertEquals(result, "Hello");
 }
+
+// `flushDb` is run against a dedicated database index (not the shared `redis` client's database) so that the
+// fixture data set up in `init.bal` and relied on by the rest of the test suite is not wiped out.
+
+@test:Config {
+    groups: ["standalone"]
+}
+function testFlushDb() returns error? {
+    if clusterMode {
+        return;
+    }
+
+    Client flushDbClient = check new (connection = {host: "localhost", port: 6379, options: {database: 14}});
+
+    string setResult = check flushDbClient->set("testFlushDbKey", "testFlushDbValue");
+    test:assertEquals(setResult, "OK");
+
+    string flushResult = check flushDbClient->flushDb();
+    test:assertEquals(flushResult, "OK");
+
+    int existsResult = check flushDbClient->exists(["testFlushDbKey"]);
+    test:assertEquals(existsResult, 0);
+
+    check flushDbClient.close();
+}
+
+// `flushAll` clears every logical database on the target server, so it is run against the isolated
+// `redis-standalone-ssl` service (port 6380) instead of the shared `redis` client's server, to avoid wiping the
+// fixture data that the rest of the test suite depends on.
+
+@test:Config {
+    groups: ["standalone"]
+}
+function testFlushAll() returns error? {
+    if clusterMode {
+        return;
+    }
+
+    Client flushAllClient = check new (
+        connection = {host: "localhost", port: 6380},
+        secureSocket = {verifyMode: NONE}
+    );
+
+    string setResult = check flushAllClient->set("testFlushAllKey", "testFlushAllValue");
+    test:assertEquals(setResult, "OK");
+
+    string flushResult = check flushAllClient->flushAll();
+    test:assertEquals(flushResult, "OK");
+
+    int existsResult = check flushAllClient->exists(["testFlushAllKey"]);
+    test:assertEquals(existsResult, 0);
+
+    check flushAllClient.close();
+}

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-- Added `flushDb` and `flushAll` remote functions to the `redis:Client` to remove all the keys from the currently selected database or from all the databases respectively
+- [Added `flushDb` and `flushAll` remote functions to the `redis:Client` to remove all the keys from the currently selected database or from all the databases respectively](https://github.com/ballerina-platform/ballerina-library/issues/8880)
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- Added `flushDb` and `flushAll` remote functions to the `redis:Client` to remove all the keys from the currently selected database or from all the databases respectively
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib.redis
-version=3.2.3-SNAPSHOT
+version=3.3.0-SNAPSHOT
 ballerinaLangVersion=2201.11.0
 
 checkstylePluginVersion=10.12.1

--- a/native/src/main/java/io/ballerina/lib/redis/ConnectionCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/ConnectionCommands.java
@@ -70,12 +70,13 @@ public class ConnectionCommands {
      * Remove all keys from all databases.
      *
      * @param redisClient Client from the Ballerina redis client
+     * @return A string with the value `OK` if the operation was successful
      */
     public static Object flushAll(BObject redisClient) {
         try {
             RedisConnectionCommandExecutor executor = getConnection(redisClient).getConnectionCommandExecutor();
-            executor.flushAll();
-            return null;
+            String response = executor.flushAll();
+            return StringUtils.fromString(response);
         } catch (Throwable e) {
             return createBError(e);
         }
@@ -85,12 +86,13 @@ public class ConnectionCommands {
      * Remove all keys from the currently selected database.
      *
      * @param redisClient Client from the Ballerina redis client
+     * @return A string with the value `OK` if the operation was successful
      */
     public static Object flushDb(BObject redisClient) {
         try {
             RedisConnectionCommandExecutor executor = getConnection(redisClient).getConnectionCommandExecutor();
-            executor.flushDb();
-            return null;
+            String response = executor.flushDb();
+            return StringUtils.fromString(response);
         } catch (Throwable e) {
             return createBError(e);
         }

--- a/native/src/main/java/io/ballerina/lib/redis/ConnectionCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/ConnectionCommands.java
@@ -67,6 +67,38 @@ public class ConnectionCommands {
     }
 
     /**
+     * Remove all keys from all databases.
+     *
+     * @param redisClient Client from the Ballerina redis client
+     * @return A string with the value `OK` if the operation was successful
+     */
+    public static Object flushAll(BObject redisClient) {
+        try {
+            RedisConnectionCommandExecutor executor = getConnection(redisClient).getConnectionCommandExecutor();
+            String response = executor.flushAll();
+            return StringUtils.fromString(response);
+        } catch (Throwable e) {
+            return createBError(e);
+        }
+    }
+
+    /**
+     * Remove all keys from the currently selected database.
+     *
+     * @param redisClient Client from the Ballerina redis client
+     * @return A string with the value `OK` if the operation was successful
+     */
+    public static Object flushDb(BObject redisClient) {
+        try {
+            RedisConnectionCommandExecutor executor = getConnection(redisClient).getConnectionCommandExecutor();
+            String response = executor.flushDb();
+            return StringUtils.fromString(response);
+        } catch (Throwable e) {
+            return createBError(e);
+        }
+    }
+
+    /**
      * Echo the given string.
      *
      * @param redisClient Client from the Ballerina redis client

--- a/native/src/main/java/io/ballerina/lib/redis/ConnectionCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/ConnectionCommands.java
@@ -70,13 +70,12 @@ public class ConnectionCommands {
      * Remove all keys from all databases.
      *
      * @param redisClient Client from the Ballerina redis client
-     * @return A string with the value `OK` if the operation was successful
      */
     public static Object flushAll(BObject redisClient) {
         try {
             RedisConnectionCommandExecutor executor = getConnection(redisClient).getConnectionCommandExecutor();
-            String response = executor.flushAll();
-            return StringUtils.fromString(response);
+            executor.flushAll();
+            return null;
         } catch (Throwable e) {
             return createBError(e);
         }
@@ -86,13 +85,12 @@ public class ConnectionCommands {
      * Remove all keys from the currently selected database.
      *
      * @param redisClient Client from the Ballerina redis client
-     * @return A string with the value `OK` if the operation was successful
      */
     public static Object flushDb(BObject redisClient) {
         try {
             RedisConnectionCommandExecutor executor = getConnection(redisClient).getConnectionCommandExecutor();
-            String response = executor.flushDb();
-            return StringUtils.fromString(response);
+            executor.flushDb();
+            return null;
         } catch (Throwable e) {
             return createBError(e);
         }

--- a/native/src/main/java/io/ballerina/lib/redis/connection/RedisConnectionCommandExecutor.java
+++ b/native/src/main/java/io/ballerina/lib/redis/connection/RedisConnectionCommandExecutor.java
@@ -65,6 +65,44 @@ public class RedisConnectionCommandExecutor {
         }
     }
 
+    public String flushAll() throws RedisConnectorException {
+        RedisClusterCommands<?, String> clusterCommands = null;
+        RedisCommands<?, String> redisCommands = null;
+        try {
+            if (connManager.isClusterConnection()) {
+                clusterCommands = (RedisAdvancedClusterCommands<?, String>) connManager.getRedisClusterCommands();
+                return clusterCommands.flushall();
+            } else {
+                redisCommands = (RedisCommands<?, String>) connManager.getRedisCommands();
+                return redisCommands.flushall();
+            }
+        } catch (RedisException e) {
+            throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);
+        } finally {
+            connManager.releaseResources(clusterCommands);
+            connManager.releaseResources(redisCommands);
+        }
+    }
+
+    public String flushDb() throws RedisConnectorException {
+        RedisClusterCommands<?, String> clusterCommands = null;
+        RedisCommands<?, String> redisCommands = null;
+        try {
+            if (connManager.isClusterConnection()) {
+                clusterCommands = (RedisAdvancedClusterCommands<?, String>) connManager.getRedisClusterCommands();
+                return clusterCommands.flushdb();
+            } else {
+                redisCommands = (RedisCommands<?, String>) connManager.getRedisCommands();
+                return redisCommands.flushdb();
+            }
+        } catch (RedisException e) {
+            throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);
+        } finally {
+            connManager.releaseResources(clusterCommands);
+            connManager.releaseResources(redisCommands);
+        }
+    }
+
     public <K> String echo(String message) throws RedisConnectorException {
         BaseRedisCommands<K, String> redisCommands = null;
         try {

--- a/native/src/main/java/io/ballerina/lib/redis/connection/RedisConnectionCommandExecutor.java
+++ b/native/src/main/java/io/ballerina/lib/redis/connection/RedisConnectionCommandExecutor.java
@@ -65,16 +65,16 @@ public class RedisConnectionCommandExecutor {
         }
     }
 
-    public void flushAll() throws RedisConnectorException {
+    public String flushAll() throws RedisConnectorException {
         RedisClusterCommands<?, String> clusterCommands = null;
         RedisCommands<?, String> redisCommands = null;
         try {
             if (connManager.isClusterConnection()) {
                 clusterCommands = (RedisAdvancedClusterCommands<?, String>) connManager.getRedisClusterCommands();
-                clusterCommands.flushall();
+                return clusterCommands.flushall();
             } else {
                 redisCommands = (RedisCommands<?, String>) connManager.getRedisCommands();
-                redisCommands.flushall();
+                return redisCommands.flushall();
             }
         } catch (RedisException e) {
             throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);
@@ -84,16 +84,16 @@ public class RedisConnectionCommandExecutor {
         }
     }
 
-    public void flushDb() throws RedisConnectorException {
+    public String flushDb() throws RedisConnectorException {
         RedisClusterCommands<?, String> clusterCommands = null;
         RedisCommands<?, String> redisCommands = null;
         try {
             if (connManager.isClusterConnection()) {
                 clusterCommands = (RedisAdvancedClusterCommands<?, String>) connManager.getRedisClusterCommands();
-                clusterCommands.flushdb();
+                return clusterCommands.flushdb();
             } else {
                 redisCommands = (RedisCommands<?, String>) connManager.getRedisCommands();
-                redisCommands.flushdb();
+                return redisCommands.flushdb();
             }
         } catch (RedisException e) {
             throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);

--- a/native/src/main/java/io/ballerina/lib/redis/connection/RedisConnectionCommandExecutor.java
+++ b/native/src/main/java/io/ballerina/lib/redis/connection/RedisConnectionCommandExecutor.java
@@ -65,16 +65,16 @@ public class RedisConnectionCommandExecutor {
         }
     }
 
-    public String flushAll() throws RedisConnectorException {
+    public void flushAll() throws RedisConnectorException {
         RedisClusterCommands<?, String> clusterCommands = null;
         RedisCommands<?, String> redisCommands = null;
         try {
             if (connManager.isClusterConnection()) {
                 clusterCommands = (RedisAdvancedClusterCommands<?, String>) connManager.getRedisClusterCommands();
-                return clusterCommands.flushall();
+                clusterCommands.flushall();
             } else {
                 redisCommands = (RedisCommands<?, String>) connManager.getRedisCommands();
-                return redisCommands.flushall();
+                redisCommands.flushall();
             }
         } catch (RedisException e) {
             throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);
@@ -84,16 +84,16 @@ public class RedisConnectionCommandExecutor {
         }
     }
 
-    public String flushDb() throws RedisConnectorException {
+    public void flushDb() throws RedisConnectorException {
         RedisClusterCommands<?, String> clusterCommands = null;
         RedisCommands<?, String> redisCommands = null;
         try {
             if (connManager.isClusterConnection()) {
                 clusterCommands = (RedisAdvancedClusterCommands<?, String>) connManager.getRedisClusterCommands();
-                return clusterCommands.flushdb();
+                clusterCommands.flushdb();
             } else {
                 redisCommands = (RedisCommands<?, String>) connManager.getRedisCommands();
-                return redisCommands.flushdb();
+                redisCommands.flushdb();
             }
         } catch (RedisException e) {
             throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);


### PR DESCRIPTION
Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8880

## Summary

Customers using this connector reported that there's no way to clear the entire cache in one call — only `del()` for named keys — forcing them to delete records one by one. This PR adds two new remote functions to `redis:Client` that wrap Redis's native `FLUSHDB`/`FLUSHALL` commands (already available via the underlying Lettuce client):

- `flushDb()` — removes all keys from the **currently selected** database
- `flushAll()` — removes all keys from **every** database on the server


## Testing

**Unit tests added** (`ballerina/tests/connection_command_tests.bal`):
- `testFlushDb` — sets a key, calls `flushDb()`, asserts the key is gone (own DB) and confirms the same call does not touch a different DB index
- `testFlushAll` — sets a key, calls `flushAll()`, asserts the key is gone

**Manual end-to-end verification** against a real local Redis 7.2.2 instance (Docker), using a standalone Ballerina program that connects two clients pointed at different logical databases (db0, db1) on the same server, to prove the `flushDb` vs `flushAll` scoping behaves as documented:

<img width="1072" height="944" alt="Screenshot 2026-07-06 at 12 08 18" src="https://github.com/user-attachments/assets/4c653df6-ae46-4ebb-8cda-18fd1b3b75fe" />



This confirms: `flushDb()` only clears the currently-selected database (db0 emptied, db1 untouched), while `flushAll()` clears every database on the server (db1 subsequently emptied too).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added `flushDb()` and `flushAll()` as new remote functions on `redis:Client` to clear the currently selected Redis database or all databases on the server. Updated the native Redis connector and command executor to implement these operations with error handling consistent with existing command wrappers.

Expanded automated tests to confirm `flushDb()` affects only the targeted database and that `flushAll()` removes keys across the server. Also updated the changelog and bumped the package version to `3.3.0-SNAPSHOT`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->