### PR TITLE
Update netty version to 4.1.135.Final

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -44,56 +44,56 @@ path = "./lib/commons-io-2.14.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.133.Final"
-path = "./lib/netty-common-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-common-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.133.Final"
-path = "./lib/netty-buffer-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-buffer-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.133.Final"
-path = "./lib/netty-transport-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-transport-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.133.Final"
-path = "./lib/netty-resolver-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-resolver-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.133.Final"
-path = "./lib/netty-handler-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-handler-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-kqueue"
-version = "4.1.133.Final"
-path = "./lib/netty-transport-native-kqueue-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-transport-native-kqueue-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-epoll"
-version = "4.1.133.Final"
-path = "./lib/netty-transport-native-epoll-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-transport-native-epoll-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.133.Final"
-path = "./lib/netty-codec-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-codec-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.133.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.133.Final.jar"
+version = "4.1.135.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.135.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.projectreactor"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ commonsPool2Version=2.11.1
 
 guavaVersion=32.0.0-jre
 commonsIoVersion=2.14.0
-nettyVersion=4.1.133.Final
+nettyVersion=4.1.135.Final
 reactorCoreVersion=3.6.2
 reactiveStreamsVersion=1.0.2


### PR DESCRIPTION
## Purpose

Fixes the failing daily Trivy scan on `master`: https://github.com/ballerina-platform/module-ballerinax-redis/actions/runs/28754378500/job/85258836671

The scan reports 5 findings in the bundled netty `4.1.133.Final` jars:

| Library | CVE | Severity |
|---|---|---|
| `netty-handler` | CVE-2026-44249 (IPv6 subnet rule bypass) | HIGH |
| `netty-handler` | CVE-2026-45416 (DoS via eager buffer allocation in TLS) | HIGH |
| `netty-handler` | CVE-2026-50010 (improper trust manager handling) | HIGH |
| `netty-transport-native-epoll` | CVE-2026-45536 (DoS via file descriptor leak) | MEDIUM |
| `netty-transport-native-kqueue` | CVE-2026-45536 (DoS via file descriptor leak) | MEDIUM |

## Fix

Bumps netty from `4.1.133.Final` to `4.1.135.Final` (staying on the 4.1.x line) in `gradle.properties` and `ballerina/Ballerina.toml`, following the same approach as the previous netty bump (#256-era commits `25984f9` / `f72b8fb`).

## Verification

- Trivy's own report lists `4.1.135.Final` as the fixed version for every finding.
- Cross-checked against the GitHub Security Advisory database (the source Trivy matches against): all four CVEs list the 4.1.x vulnerable range as `<= 4.1.134.Final` with first patched version `4.1.135.Final`:
  - [GHSA for CVE-2026-44249](https://github.com/advisories?query=CVE-2026-44249)
  - [GHSA for CVE-2026-45416](https://github.com/advisories?query=CVE-2026-45416)
  - [GHSA for CVE-2026-50010](https://github.com/advisories?query=CVE-2026-50010)
  - [GHSA for CVE-2026-45536](https://github.com/advisories?query=CVE-2026-45536)
- All nine netty `4.1.135.Final` artifacts referenced in `Ballerina.toml` verified present on Maven Central.
- The existing `.trivyignore` entry (CVE-2026-42577) remains valid — that advisory only affects the 4.2.x line.

The next scheduled Trivy run on `master` after merging will confirm the scan passes end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Netty dependency version from `4.1.133.Final` to `4.1.135.Final` across Gradle and Ballerina platform configuration.

This change keeps the bundled Netty artifacts in sync, including the local jar references in `Ballerina.toml`, and aligns the project with the newer fixed release to improve dependency maintenance and keep scan results up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->