### PR TITLE
Fix mGet returning InherentTypeViolation when a key is missing

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -218,13 +218,14 @@ public isolated client class Client {
         'class: "io.ballerina.lib.redis.StringCommands"
     } external;
 
-    # Get values of all given keys.
+    # Get values of all given keys. A key that does not exist is represented as `()` in the
+    # returned array, matching the nil-safe behavior of `get`.
     #
     # + keys - Keys of which values need to be retrieved
-    # + return - Array of values at specified keys
+    # + return - Array of values at specified keys, with `()` for a missing key
     @display {label: "Get Values"}
     isolated remote function mGet(@display {label: "Keys"} string[] keys)
-                          returns @display {label: "Values"} string[]|Error = @java:Method {
+                          returns @display {label: "Values"} string?[]|Error = @java:Method {
         'class: "io.ballerina.lib.redis.StringCommands"
     } external;
 

--- a/ballerina/tests/string_command_tests.bal
+++ b/ballerina/tests/string_command_tests.bal
@@ -163,15 +163,29 @@ public function testIncrByFloat() returns error? {
     groups: ["standalone", "cluster"]
 }
 function testMGet() returns error? {
-    string[] result = check redis->mGet(["testMGetKey1", "testMGetKey2"]);
-    test:assertEquals(result.length(), 2);
+    string?[] result = check redis->mGet(["testMGetKey1", "testMGetKey2"]);
+    test:assertEquals(result, ["testMGetValue1", "testMGetValue2"]);
+}
 
-    string? getResult1 = check redis->get("testMGetKey1");
-    test:assertEquals(getResult1, "testMGetValue1");
-    string? getResult2 = check redis->get("testMGetKey2");
-    test:assertEquals(getResult2, "testMGetValue2");
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
+function testMGetWithMissingKey() returns error? {
     string? getResult3 = check redis->get("testMGetKey3");
     test:assertEquals(getResult3, ());
+
+    // A missing key ("testMGetKey3") must surface as `()` at its position instead of
+    // failing the whole call with an InherentTypeViolation.
+    string?[] result = check redis->mGet(["testMGetKey1", "testMGetKey3", "testMGetKey2"]);
+    test:assertEquals(result, ["testMGetValue1", (), "testMGetValue2"]);
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
+function testMGetWithAllMissingKeys() returns error? {
+    string?[] result = check redis->mGet(["nonExistentMGetKey1", "nonExistentMGetKey2"]);
+    test:assertEquals(result, [(), ()]);
 }
 
 @test:Config {

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Fixed client initialization for empty connection configs](https://github.com/ballerina-platform/ballerina-library/issues/6157)
+- [Fixed `mGet` returning an `InherentTypeViolation` error when a requested key does not exist](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ## [3.0.0] - 2024-03-08
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,10 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Added `flushDb` and `flushAll` remote functions to the `redis:Client` to remove all the keys from the currently selected database or from all the databases respectively](https://github.com/ballerina-platform/ballerina-library/issues/8880)
 
 ### Changed
+- [**Breaking change:** Changed `mGet`'s return type from `string[]|Error` to `string?[]|Error` to fix a `redis:Error` (`InherentTypeViolation`) that occurred whenever a requested key did not exist; a missing key is now represented as `()`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ### Fixed
 - [Fixed client initialization for empty connection configs](https://github.com/ballerina-platform/ballerina-library/issues/6157)
-- [Fixed `mGet` returning an `InherentTypeViolation` error when a requested key does not exist](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ## [3.0.0] - 2024-03-08
 

--- a/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
@@ -26,7 +26,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 
 import static io.ballerina.lib.redis.utils.ConversionUtils.createBError;
-import static io.ballerina.lib.redis.utils.ConversionUtils.createBStringArrayFromBMap;
+import static io.ballerina.lib.redis.utils.ConversionUtils.createBNilableStringArrayFromBMap;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createMapFromBMap;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createStringArrayFromBArray;
 import static io.ballerina.lib.redis.utils.RedisUtils.getConnection;
@@ -304,7 +304,7 @@ public class StringCommands {
     public static Object mGet(BObject redisClient, BArray keys) {
         try {
             RedisStringCommandExecutor executor = getConnection(redisClient).getStringCommandExecutor();
-            return createBStringArrayFromBMap(executor.mGet(createStringArrayFromBArray(keys)));
+            return createBNilableStringArrayFromBMap(executor.mGet(createStringArrayFromBArray(keys)));
         } catch (Throwable e) {
             return createBError(e);
         }

--- a/native/src/main/java/io/ballerina/lib/redis/utils/ConversionUtils.java
+++ b/native/src/main/java/io/ballerina/lib/redis/utils/ConversionUtils.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.PredefinedTypes;
+import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
@@ -158,13 +159,17 @@ public class ConversionUtils {
     }
 
     /**
-     * Create a Ballerina array value from a Ballerina map value.
+     * Create a Ballerina nilable-string array value from a Ballerina map value. A {@code null} entry value
+     * (a key that does not exist in Redis) is preserved as {@code ()} instead of raising an
+     * {@code InherentTypeViolation}, matching Redis' {@code MGET} semantics of returning nil for missing keys.
      *
      * @param bMap the Ballerina map value
      * @return the Ballerina array
      */
-    public static BArray createBStringArrayFromBMap(BMap<BString, Object> bMap) {
-        BArray bStringArray = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
+    public static BArray createBNilableStringArrayFromBMap(BMap<BString, Object> bMap) {
+        UnionType nilableStringType = TypeCreator.createUnionType(PredefinedTypes.TYPE_STRING,
+                PredefinedTypes.TYPE_NULL);
+        BArray bStringArray = ValueCreator.createArrayValue(TypeCreator.createArrayType(nilableStringType));
         for (Map.Entry<BString, Object> entry : bMap.entrySet()) {
             bStringArray.append(entry.getValue());
         }


### PR DESCRIPTION
## Purpose

Redis' `MGET` returns `nil` for any key that does not exist. `mGet`'s return type declared a non-nullable `string[]` element type, so the runtime could not represent that `nil` and raised a `redis:Error` (`{ballerina/lang.array}InherentTypeViolation`) for the *entire* call whenever **any** requested key was missing — which is the common case for `MGET` (fetching several keys where some may not be set yet). There was no way to retrieve the values that did exist.

`get` already handles this correctly (`string|Error?`, nil for a missing key); `mGet` just wasn't given the same nilable treatment for its array elements.

**Fix:** change `mGet`'s return type to `string?[]|Error` and build the native array with a nilable `string` element type (`ConversionUtils.createBNilableStringArrayFromBMap`), instead of the non-nullable `string` type used previously. The upstream `KeyValue` → Ballerina-map conversion (`createBMapFromKeyValueList`) already stored `null` correctly for missing keys — the non-nullable array type on the way back out was the only broken link.

**⚠️ Breaking change:** this changes `mGet`'s public return type from `string[]|Error` to `string?[]|Error`. Existing code written as `string[] result = check redis->mGet([...]);` will no longer compile. Given the project bumped `2.x → 3.0.0` previously for a comparable breaking signature change (generic `error` → `redis:Error`), this may warrant a major version bump rather than shipping in a patch release — flagging for maintainers to decide at release time.

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8889

## Examples

```ballerina
_ = check redis->set("present", "value");
_ = check redis->del(["absent"]);

// Before: fails entirely because "absent" is missing
string[]|redis:Error values = redis->mGet(["present", "absent"]);
// -> error: {ballerina/lang.array}InherentTypeViolation

// After: succeeds, missing key surfaces as () at its position
string?[] values = check redis->mGet(["present", "absent"]);
// -> ["value", ()]
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated Redis `mGet` to return `string?[]|Error`, representing missing keys as `()` in their corresponding positions instead of failing the entire call.
- Updated native conversion logic to construct a nilable string element array for the `mGet` result.
- Enhanced Redis string command tests to cover mixed results, missing-only requests, and position-preserving `()` outputs.
- Documented the behavior change in the changelog as a breaking change due to the `mGet` return-type update.

This return-type change may require consumer code updates for users currently expecting `string[]`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->