### PR TITLE
Add setNxEx remote function for atomic SET NX EX

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -327,6 +327,21 @@ public isolated client class Client {
         'class: "io.ballerina.lib.redis.StringCommands"
     } external;
 
+    # Set the value and expiration of a key, only if the key does not exist. Combines `setNx` and `setEx`
+    # into a single atomic operation (`SET key value NX EX expirationTime`).
+    #
+    # + key - Key referring to a value
+    # + value - Value to be set
+    # + expirationTime - Expiration time to be set, in seconds
+    # + return - `True` if the key was set, `False` if the key already existed, or `redis:Error` if an error occurs
+    @display {label: "Set Expirable Value If Absent"}
+    isolated remote function setNxEx(@display {label: "Key"} string key,
+                                     @display {label: "Value"} string value,
+                                     @display {label: "TTL (s)"} int expirationTime)
+                             returns @display {label: "Result"} boolean|Error = @java:Method {
+        'class: "io.ballerina.lib.redis.StringCommands"
+    } external;
+
     # Overwrite part of string at key starting at the specified offset.
     #
     # + key - Key referring to a value

--- a/ballerina/tests/string_command_tests.bal
+++ b/ballerina/tests/string_command_tests.bal
@@ -319,6 +319,36 @@ public function testSetNx() returns error? {
 @test:Config {
     groups: ["standalone", "cluster"]
 }
+public function testSetNxEx() returns error? {
+    boolean result = check redis->setNxEx("testSetNxExKey", "testSetNxExValue", 1);
+    test:assertEquals(result, true);
+
+    string? getResult = check redis->get("testSetNxExKey");
+    test:assertEquals(getResult, "testSetNxExValue");
+
+    boolean result2 = check redis->setNxEx("testSetNxExKey", "anotherValue", 1);
+    test:assertEquals(result2, false);
+
+    string? getResult2 = check redis->get("testSetNxExKey");
+    test:assertEquals(getResult2, "testSetNxExValue");
+
+    // NX must refuse based on key existence alone, regardless of the existing value's type -
+    // it should not error or overwrite even when the key holds a non-string value.
+    int pushResult = check redis->lPush("testSetNxExListKey", ["listValue"]);
+    test:assertEquals(pushResult, 1);
+    boolean result4 = check redis->setNxEx("testSetNxExListKey", "shouldNotBeSet", 1);
+    test:assertEquals(result4, false);
+    string[] listResult = check redis->lRange("testSetNxExListKey", 0, -1);
+    test:assertEquals(listResult, ["listValue"]);
+
+    runtime:sleep(2);
+    string? getResult3 = check redis->get("testSetNxExKey");
+    test:assertEquals(getResult3, ());
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
 public function testSetRange() returns error? {
     int result = check redis->setRange("testSetRangeKey", 2, "!!!");
     test:assertEquals(result, 17);

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [Added `mGetOptional`, a nil-safe variant of `mGet` that represents a missing key as `()`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
+- [Added a `setNxEx` remote function to the `redis:Client` to atomically set a key's value and expiration only if the key does not already exist (`SET key value NX EX ttl`)](https://github.com/ballerina-platform/ballerina-library/issues/8907)
 
 ### Changed
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -380,6 +380,7 @@ Ballerina Redis connector supports the following string operations:
 - `setBit`: Sets or clears the bit at an offset in the string value stored at a key.
 - `setEx`: Sets the value and expiration of a key in seconds.
 - `setNx`: Sets the value of a key, only if the key does not exist.
+- `setNxEx`: Sets the value and expiration of a key, only if the key does not exist.
 - `setRange`: Overwrites part of a string at a key starting at the specified offset.
 - `strLen`: Gets the length of the value stored in a key.
 

--- a/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
@@ -451,6 +451,24 @@ public class StringCommands {
     }
 
     /**
+     * Set the value and expiration of a key, only if the key does not exist.
+     *
+     * @param redisClient             Client from the Ballerina redis client
+     * @param key                     key
+     * @param value                   value
+     * @param expirationPeriodSeconds Expiration time to be set, in seconds
+     * @return `True` if the key was set, `False` if the key already existed
+     */
+    public static Object setNxEx(BObject redisClient, BString key, BString value, long expirationPeriodSeconds) {
+        try {
+            RedisStringCommandExecutor executor = getConnection(redisClient).getStringCommandExecutor();
+            return executor.setNxEx(key.getValue(), value.getValue(), expirationPeriodSeconds);
+        } catch (Throwable e) {
+            return createBError(e);
+        }
+    }
+
+    /**
      * Overwrite part of a string at key starting at the specified offset.
      *
      * @param redisClient Client from the Ballerina redis client

--- a/native/src/main/java/io/ballerina/lib/redis/connection/RedisStringCommandExecutor.java
+++ b/native/src/main/java/io/ballerina/lib/redis/connection/RedisStringCommandExecutor.java
@@ -21,6 +21,7 @@ package io.ballerina.lib.redis.connection;
 import io.ballerina.lib.redis.exceptions.RedisConnectorException;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisException;
+import io.lettuce.core.SetArgs;
 import io.lettuce.core.api.sync.RedisStringCommands;
 
 import java.util.List;
@@ -356,6 +357,21 @@ public class RedisStringCommandExecutor {
         try {
             stringCommands = (RedisStringCommands<K, String>) connManager.getStringCommandConnection();
             return stringCommands.setnx(key, value);
+        } catch (IllegalArgumentException e) {
+            throw new RedisConnectorException(KEY_MUST_NOT_BE_NULL, e);
+        } catch (RedisException e) {
+            throw new RedisConnectorException(REDIS_SERVER_ERROR + e.getMessage(), e);
+        } finally {
+            connManager.releaseResources(stringCommands);
+        }
+    }
+
+    public <K> boolean setNxEx(K key, String value, long expirationPeriodSeconds) throws RedisConnectorException {
+        RedisStringCommands<K, String> stringCommands = null;
+        try {
+            stringCommands = (RedisStringCommands<K, String>) connManager.getStringCommandConnection();
+            String result = stringCommands.set(key, value, SetArgs.Builder.ex(expirationPeriodSeconds).nx());
+            return result != null;
         } catch (IllegalArgumentException e) {
             throw new RedisConnectorException(KEY_MUST_NOT_BE_NULL, e);
         } catch (RedisException e) {


### PR DESCRIPTION
## Purpose

`setNx` (atomic, no TTL) and `setEx` (TTL, but always overwrites) each cover only half of what Redis's `SET key value NX EX ttl` already does natively, atomically, since Redis 2.6.12. Combining them today requires two separate calls (`setNx` then `expire`), which reintroduces the exact non-atomicity `NX EX` exists to avoid: a crash between the two calls leaves a key with no TTL.

**Fix:** add `setNxEx`, wrapping Lettuce's `set(key, value, SetArgs.Builder.ex(ttl).nx())` so the combined NX+EX write happens as a single atomic Redis command, following the same pattern as the existing `setNx`/`setEx` methods.

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/8907

## Examples

```ballerina
import ballerinax/redis;

public function main() returns error? {
    redis:Client redis = check new ({
        connection: {host: "localhost", port: 6379}
    });

    boolean acquired = check redis->setNxEx("session:lock", "1", 60);
    // acquired == true  -> lock created, expires in 60s
    // acquired == false -> lock already held; existing value and TTL are untouched
}
```

Also verified `setNxEx` correctly refuses (returns `false`, no error) when the key already exists as a non-string type (e.g. a list) — Redis's `NX` check is existence-based, not type-based, so it never reaches the type-specific write path.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a `setNxEx` Redis client operation that atomically sets a key only when it does not already exist and applies an expiration time. Updates the native implementation, public API declarations, specification and changelog, and introduces tests covering key creation, behavior when the key exists (including non-string values), and TTL expiry; test timing was also shortened to keep runs efficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->