### PR TITLE
Fix mGet duplicate-key handling and add mGetOptional

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -218,13 +218,26 @@ public isolated client class Client {
         'class: "io.ballerina.lib.redis.StringCommands"
     } external;
 
-    # Get values of all given keys.
+    # Get values of all given keys. Fails with an `Error` if any of the given keys does not
+    # exist, since the returned type cannot represent a missing value. Use `mGetNilable` instead
+    # if any of the given keys might not exist.
     #
     # + keys - Keys of which values need to be retrieved
     # + return - Array of values at specified keys
     @display {label: "Get Values"}
     isolated remote function mGet(@display {label: "Keys"} string[] keys)
                           returns @display {label: "Values"} string[]|Error = @java:Method {
+        'class: "io.ballerina.lib.redis.StringCommands"
+    } external;
+
+    # Get values of all given keys. Unlike `mGet`, a key that does not exist is represented as
+    # `()` in the returned array instead of causing the call to fail.
+    #
+    # + keys - Keys of which values need to be retrieved
+    # + return - Array of values at specified keys, with `()` for a missing key
+    @display {label: "Get Values (Nilable)"}
+    isolated remote function mGetNilable(@display {label: "Keys"} string[] keys)
+                          returns @display {label: "Values"} string?[]|Error = @java:Method {
         'class: "io.ballerina.lib.redis.StringCommands"
     } external;
 

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -231,7 +231,7 @@ public isolated client class Client {
     } external;
 
     # Get values of all given keys. Unlike `mGet`, a key that does not exist is represented as
-    # `()` in the returned array instead of causing the call to fail.
+    # `()` in the returned array.
     #
     # + keys - Keys of which values need to be retrieved
     # + return - Array of values at specified keys, with `()` for a missing key

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -219,7 +219,7 @@ public isolated client class Client {
     } external;
 
     # Get values of all given keys. Fails with an `Error` if any of the given keys does not
-    # exist, since the returned type cannot represent a missing value. Use `mGetNilable` instead
+    # exist, since the returned type cannot represent a missing value. Use `mGetOptional` instead
     # if any of the given keys might not exist.
     #
     # + keys - Keys of which values need to be retrieved
@@ -235,8 +235,8 @@ public isolated client class Client {
     #
     # + keys - Keys of which values need to be retrieved
     # + return - Array of values at specified keys, with `()` for a missing key
-    @display {label: "Get Values (Nilable)"}
-    isolated remote function mGetNilable(@display {label: "Keys"} string[] keys)
+    @display {label: "Get Values (Optional)"}
+    isolated remote function mGetOptional(@display {label: "Keys"} string[] keys)
                           returns @display {label: "Values"} string?[]|Error = @java:Method {
         'class: "io.ballerina.lib.redis.StringCommands"
     } external;

--- a/ballerina/tests/string_command_tests.bal
+++ b/ballerina/tests/string_command_tests.bal
@@ -186,6 +186,49 @@ function testMGetWithDuplicateKeys() returns error? {
 @test:Config {
     groups: ["standalone", "cluster"]
 }
+function testMGetWithMissingKeyError() returns error? {
+    string[]|Error result = redis->mGet(["testMGetKey1", "testMGetKey3"]);
+    test:assertTrue(result is Error);
+    if result is Error {
+        test:assertEquals(result.message(), "One or more keys returned nil, which cannot be represented in mGet. Use mGetNilable instead.");
+    }
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
+function testMGetNilable() returns error? {
+    string?[] result = check redis->mGetNilable(["testMGetKey1", "testMGetKey2"]);
+    test:assertEquals(result, ["testMGetValue1", "testMGetValue2"]);
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
+function testMGetNilableWithMissingKey() returns error? {
+    string?[] result = check redis->mGetNilable(["testMGetKey1", "testMGetKey3", "testMGetKey2"]);
+    test:assertEquals(result, ["testMGetValue1", (), "testMGetValue2"]);
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
+function testMGetNilableWithAllMissingKeys() returns error? {
+    string?[] result = check redis->mGetNilable(["nonExistentMGetKey1", "nonExistentMGetKey2"]);
+    test:assertEquals(result, [(), ()]);
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
+function testMGetNilableWithDuplicateKeys() returns error? {
+    string?[] result = check redis->mGetNilable(["testMGetKey1", "testMGetKey2", "testMGetKey1"]);
+    test:assertEquals(result, ["testMGetValue1", "testMGetValue2", "testMGetValue1"]);
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
 function testMSet() returns error? {
     map<any> keyValueMap = {
         testMSetKey1: "testMSetValue1",

--- a/ballerina/tests/string_command_tests.bal
+++ b/ballerina/tests/string_command_tests.bal
@@ -190,39 +190,39 @@ function testMGetWithMissingKeyError() returns error? {
     string[]|Error result = redis->mGet(["testMGetKey1", "testMGetKey3"]);
     test:assertTrue(result is Error);
     if result is Error {
-        test:assertEquals(result.message(), "One or more keys returned nil, which cannot be represented in mGet. Use mGetNilable instead.");
+        test:assertEquals(result.message(), "One or more keys returned nil, which cannot be represented in mGet. Use mGetOptional instead.");
     }
 }
 
 @test:Config {
     groups: ["standalone", "cluster"]
 }
-function testMGetNilable() returns error? {
-    string?[] result = check redis->mGetNilable(["testMGetKey1", "testMGetKey2"]);
+function testMGetOptional() returns error? {
+    string?[] result = check redis->mGetOptional(["testMGetKey1", "testMGetKey2"]);
     test:assertEquals(result, ["testMGetValue1", "testMGetValue2"]);
 }
 
 @test:Config {
     groups: ["standalone", "cluster"]
 }
-function testMGetNilableWithMissingKey() returns error? {
-    string?[] result = check redis->mGetNilable(["testMGetKey1", "testMGetKey3", "testMGetKey2"]);
+function testMGetOptionalWithMissingKey() returns error? {
+    string?[] result = check redis->mGetOptional(["testMGetKey1", "testMGetKey3", "testMGetKey2"]);
     test:assertEquals(result, ["testMGetValue1", (), "testMGetValue2"]);
 }
 
 @test:Config {
     groups: ["standalone", "cluster"]
 }
-function testMGetNilableWithAllMissingKeys() returns error? {
-    string?[] result = check redis->mGetNilable(["nonExistentMGetKey1", "nonExistentMGetKey2"]);
+function testMGetOptionalWithAllMissingKeys() returns error? {
+    string?[] result = check redis->mGetOptional(["nonExistentMGetKey1", "nonExistentMGetKey2"]);
     test:assertEquals(result, [(), ()]);
 }
 
 @test:Config {
     groups: ["standalone", "cluster"]
 }
-function testMGetNilableWithDuplicateKeys() returns error? {
-    string?[] result = check redis->mGetNilable(["testMGetKey1", "testMGetKey2", "testMGetKey1"]);
+function testMGetOptionalWithDuplicateKeys() returns error? {
+    string?[] result = check redis->mGetOptional(["testMGetKey1", "testMGetKey2", "testMGetKey1"]);
     test:assertEquals(result, ["testMGetValue1", "testMGetValue2", "testMGetValue1"]);
 }
 

--- a/ballerina/tests/string_command_tests.bal
+++ b/ballerina/tests/string_command_tests.bal
@@ -177,6 +177,15 @@ function testMGet() returns error? {
 @test:Config {
     groups: ["standalone", "cluster"]
 }
+function testMGetWithDuplicateKeys() returns error? {
+    // A repeated key must produce a repeated result at its position, not collapse into one.
+    string[] result = check redis->mGet(["testMGetKey1", "testMGetKey2", "testMGetKey1"]);
+    test:assertEquals(result, ["testMGetValue1", "testMGetValue2", "testMGetValue1"]);
+}
+
+@test:Config {
+    groups: ["standalone", "cluster"]
+}
 function testMSet() returns error? {
     map<any> keyValueMap = {
         testMSetKey1: "testMSetValue1",

--- a/changelog.md
+++ b/changelog.md
@@ -7,12 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - [Added `flushDb` and `flushAll` remote functions to the `redis:Client` to remove all the keys from the currently selected database or from all the databases respectively](https://github.com/ballerina-platform/ballerina-library/issues/8880)
+- [Added `mGetNilable`, a nil-safe variant of `mGet` that represents a missing key as `()` instead of failing](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ### Changed
 
 ### Fixed
 - [Fixed client initialization for empty connection configs](https://github.com/ballerina-platform/ballerina-library/issues/6157)
 - [Fixed `mGet` returning fewer results than requested when the key list contained duplicates](https://github.com/ballerina-platform/ballerina-library/issues/8908)
+- [Fixed `mGet` failing with a raw `InherentTypeViolation` error when a key does not exist; it now fails with a clear message pointing to `mGetNilable`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ## [3.0.0] - 2024-03-08
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,15 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- [Added `mGetNilable`, a nil-safe variant of `mGet` that represents a missing key as `()`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
+
+### Changed
+
+### Fixed
+- [Fixed `mGet` returning fewer results than requested when the key list contained duplicates](https://github.com/ballerina-platform/ballerina-library/issues/8908)
+- [Fixed `mGet` failing with a raw `InherentTypeViolation` error when a key does not exist; it now fails with a clear message pointing to `mGetNilable`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
+
+## [3.3.0] - 2026-07-06
+
+### Added
 - [Added `flushDb` and `flushAll` remote functions to the `redis:Client` to remove all the keys from the currently selected database or from all the databases respectively](https://github.com/ballerina-platform/ballerina-library/issues/8880)
-- [Added `mGetNilable`, a nil-safe variant of `mGet` that represents a missing key as `()` instead of failing](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ### Changed
 
 ### Fixed
 - [Fixed client initialization for empty connection configs](https://github.com/ballerina-platform/ballerina-library/issues/6157)
-- [Fixed `mGet` returning fewer results than requested when the key list contained duplicates](https://github.com/ballerina-platform/ballerina-library/issues/8908)
-- [Fixed `mGet` failing with a raw `InherentTypeViolation` error when a key does not exist; it now fails with a clear message pointing to `mGetNilable`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ## [3.0.0] - 2024-03-08
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,13 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-- [Added `mGetNilable`, a nil-safe variant of `mGet` that represents a missing key as `()`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
+- [Added `mGetOptional`, a nil-safe variant of `mGet` that represents a missing key as `()`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ### Changed
 
 ### Fixed
 - [Fixed `mGet` returning fewer results than requested when the key list contained duplicates](https://github.com/ballerina-platform/ballerina-library/issues/8908)
-- [Fixed `mGet` failing with a raw `InherentTypeViolation` error when a key does not exist; it now fails with a clear message pointing to `mGetNilable`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
+- [Fixed `mGet` failing with a raw `InherentTypeViolation` error when a key does not exist; it now fails with a clear message pointing to `mGetOptional`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
 
 ## [3.3.0] - 2026-07-06
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Fixed client initialization for empty connection configs](https://github.com/ballerina-platform/ballerina-library/issues/6157)
+- [Fixed `mGet` returning fewer results than requested when the key list contained duplicates](https://github.com/ballerina-platform/ballerina-library/issues/8908)
 
 ## [3.0.0] - 2024-03-08
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -371,7 +371,7 @@ Ballerina Redis connector supports the following string operations:
 - `incr`: Increments the integer value of a key by one.
 - `incrBy`: Increments the integer value of a key by a given amount.
 - `incrByFloat`: Increments the float value of a key by a given amount.
-- `mGet`: Gets the values of multiple keys.
+- `mGet`: Gets the values of multiple keys. Fails if any key does not exist; use `mGetNilable` if a key might not exist.
 - `mGetNilable`: Gets the values of multiple keys, representing a missing key as `()`.
 - `mSet`: Sets multiple keys to multiple values.
 - `mSetNx`: Sets multiple keys to multiple values, only if none of the keys exist.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -371,8 +371,8 @@ Ballerina Redis connector supports the following string operations:
 - `incr`: Increments the integer value of a key by one.
 - `incrBy`: Increments the integer value of a key by a given amount.
 - `incrByFloat`: Increments the float value of a key by a given amount.
-- `mGet`: Gets the values of multiple keys. Fails if any key does not exist; use `mGetNilable` if a key might not exist.
-- `mGetNilable`: Gets the values of multiple keys, representing a missing key as `()`.
+- `mGet`: Gets the values of multiple keys. Fails if any key does not exist; use `mGetOptional` if a key might not exist.
+- `mGetOptional`: Gets the values of multiple keys, representing a missing key as `()`.
 - `mSet`: Sets multiple keys to multiple values.
 - `mSetNx`: Sets multiple keys to multiple values, only if none of the keys exist.
 - `pSetEx`: Sets the value and expiration in milliseconds of a key.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -372,6 +372,7 @@ Ballerina Redis connector supports the following string operations:
 - `incrBy`: Increments the integer value of a key by a given amount.
 - `incrByFloat`: Increments the float value of a key by a given amount.
 - `mGet`: Gets the values of multiple keys.
+- `mGetNilable`: Gets the values of multiple keys, representing a missing key as `()`.
 - `mSet`: Sets multiple keys to multiple values.
 - `mSetNx`: Sets multiple keys to multiple values, only if none of the keys exist.
 - `pSetEx`: Sets the value and expiration in milliseconds of a key.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib.redis
-version=3.3.1-SNAPSHOT
+version=3.4.0-SNAPSHOT
 ballerinaLangVersion=2201.11.0
 
 checkstylePluginVersion=10.12.1

--- a/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
@@ -26,7 +26,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 
 import static io.ballerina.lib.redis.utils.ConversionUtils.createBError;
-import static io.ballerina.lib.redis.utils.ConversionUtils.createBStringArrayFromBMap;
+import static io.ballerina.lib.redis.utils.ConversionUtils.createBStringArrayFromKeyValueList;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createMapFromBMap;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createStringArrayFromBArray;
 import static io.ballerina.lib.redis.utils.RedisUtils.getConnection;
@@ -304,7 +304,7 @@ public class StringCommands {
     public static Object mGet(BObject redisClient, BArray keys) {
         try {
             RedisStringCommandExecutor executor = getConnection(redisClient).getStringCommandExecutor();
-            return createBStringArrayFromBMap(executor.mGet(createStringArrayFromBArray(keys)));
+            return createBStringArrayFromKeyValueList(executor.mGet(createStringArrayFromBArray(keys)));
         } catch (Throwable e) {
             return createBError(e);
         }

--- a/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
@@ -297,7 +297,7 @@ public class StringCommands {
 
     /**
      * Get the values of all the given keys. Fails if any key has no value; use
-     * {@link #mGetNilable(BObject, BArray)} if a key might not exist.
+     * {@link #mGetOptional(BObject, BArray)} if a key might not exist.
      *
      * @param redisClient Client from the Ballerina redis client
      * @param keys        The keys of which the values need to be retrieved
@@ -320,7 +320,7 @@ public class StringCommands {
      * @param keys        The keys of which the values need to be retrieved
      * @return Array of values at the specified keys, with {@code ()} for a missing key
      */
-    public static Object mGetNilable(BObject redisClient, BArray keys) {
+    public static Object mGetOptional(BObject redisClient, BArray keys) {
         try {
             RedisStringCommandExecutor executor = getConnection(redisClient).getStringCommandExecutor();
             return createBNilableStringArrayFromKeyValueList(executor.mGet(createStringArrayFromBArray(keys)));

--- a/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
@@ -314,7 +314,7 @@ public class StringCommands {
 
     /**
      * Get the values of all the given keys. Unlike {@link #mGet(BObject, BArray)}, a key that has
-     * no value is represented as {@code ()} in the returned array instead of failing.
+     * no value is represented as {@code ()} in the returned array.
      *
      * @param redisClient Client from the Ballerina redis client
      * @param keys        The keys of which the values need to be retrieved

--- a/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
+++ b/native/src/main/java/io/ballerina/lib/redis/StringCommands.java
@@ -26,6 +26,7 @@ import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 
 import static io.ballerina.lib.redis.utils.ConversionUtils.createBError;
+import static io.ballerina.lib.redis.utils.ConversionUtils.createBNilableStringArrayFromKeyValueList;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createBStringArrayFromKeyValueList;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createMapFromBMap;
 import static io.ballerina.lib.redis.utils.ConversionUtils.createStringArrayFromBArray;
@@ -295,7 +296,8 @@ public class StringCommands {
     }
 
     /**
-     * Get the values of all the given keys.
+     * Get the values of all the given keys. Fails if any key has no value; use
+     * {@link #mGetNilable(BObject, BArray)} if a key might not exist.
      *
      * @param redisClient Client from the Ballerina redis client
      * @param keys        The keys of which the values need to be retrieved
@@ -305,6 +307,23 @@ public class StringCommands {
         try {
             RedisStringCommandExecutor executor = getConnection(redisClient).getStringCommandExecutor();
             return createBStringArrayFromKeyValueList(executor.mGet(createStringArrayFromBArray(keys)));
+        } catch (Throwable e) {
+            return createBError(e);
+        }
+    }
+
+    /**
+     * Get the values of all the given keys. Unlike {@link #mGet(BObject, BArray)}, a key that has
+     * no value is represented as {@code ()} in the returned array instead of failing.
+     *
+     * @param redisClient Client from the Ballerina redis client
+     * @param keys        The keys of which the values need to be retrieved
+     * @return Array of values at the specified keys, with {@code ()} for a missing key
+     */
+    public static Object mGetNilable(BObject redisClient, BArray keys) {
+        try {
+            RedisStringCommandExecutor executor = getConnection(redisClient).getStringCommandExecutor();
+            return createBNilableStringArrayFromKeyValueList(executor.mGet(createStringArrayFromBArray(keys)));
         } catch (Throwable e) {
             return createBError(e);
         }

--- a/native/src/main/java/io/ballerina/lib/redis/connection/RedisStringCommandExecutor.java
+++ b/native/src/main/java/io/ballerina/lib/redis/connection/RedisStringCommandExecutor.java
@@ -19,8 +19,6 @@
 package io.ballerina.lib.redis.connection;
 
 import io.ballerina.lib.redis.exceptions.RedisConnectorException;
-import io.ballerina.runtime.api.values.BMap;
-import io.ballerina.runtime.api.values.BString;
 import io.lettuce.core.KeyValue;
 import io.lettuce.core.RedisException;
 import io.lettuce.core.api.sync.RedisStringCommands;
@@ -31,7 +29,6 @@ import java.util.Map;
 import static io.ballerina.lib.redis.utils.Constants.KEYS_MUST_NOT_BE_NULL;
 import static io.ballerina.lib.redis.utils.Constants.KEY_MUST_NOT_BE_NULL;
 import static io.ballerina.lib.redis.utils.Constants.REDIS_SERVER_ERROR;
-import static io.ballerina.lib.redis.utils.ConversionUtils.createBMapFromKeyValueList;
 
 /**
  * Executor implementation for Redis string commands.
@@ -270,12 +267,11 @@ public class RedisStringCommandExecutor {
         }
     }
 
-    public <K> BMap<BString, Object> mGet(K[] key) throws RedisConnectorException {
+    public <K> List<KeyValue<K, String>> mGet(K[] key) throws RedisConnectorException {
         RedisStringCommands<K, String> stringCommands = null;
         try {
             stringCommands = (RedisStringCommands<K, String>) connManager.getStringCommandConnection();
-            List<KeyValue<K, String>> result = stringCommands.mget(key);
-            return createBMapFromKeyValueList(result);
+            return stringCommands.mget(key);
         } catch (IllegalArgumentException e) {
             throw new RedisConnectorException(KEYS_MUST_NOT_BE_NULL, e);
         } catch (RedisException e) {

--- a/native/src/main/java/io/ballerina/lib/redis/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/lib/redis/utils/Constants.java
@@ -38,7 +38,7 @@ public class Constants {
     public static final String ARGUMENTS_MUST_NOT_BE_NULL = "Arguments " + MUST_NOT_BE_NULL;
     public static final String REDIS_SERVER_ERROR = "Redis server error: ";
     public static final String MGET_NIL_VALUE_ERROR =
-            "One or more keys returned nil, which cannot be represented in mGet. Use mGetNilable instead.";
+            "One or more keys returned nil, which cannot be represented in mGet. Use mGetOptional instead.";
 
     // Other constants
     public static final String EMPTY_STRING = "";

--- a/native/src/main/java/io/ballerina/lib/redis/utils/Constants.java
+++ b/native/src/main/java/io/ballerina/lib/redis/utils/Constants.java
@@ -37,6 +37,8 @@ public class Constants {
     public static final String KEYS_MUST_NOT_BE_NULL = "Key(s) " + MUST_NOT_BE_NULL;
     public static final String ARGUMENTS_MUST_NOT_BE_NULL = "Arguments " + MUST_NOT_BE_NULL;
     public static final String REDIS_SERVER_ERROR = "Redis server error: ";
+    public static final String MGET_NIL_VALUE_ERROR =
+            "One or more keys returned nil, which cannot be represented in mGet. Use mGetNilable instead.";
 
     // Other constants
     public static final String EMPTY_STRING = "";

--- a/native/src/main/java/io/ballerina/lib/redis/utils/ConversionUtils.java
+++ b/native/src/main/java/io/ballerina/lib/redis/utils/ConversionUtils.java
@@ -18,10 +18,12 @@
 
 package io.ballerina.lib.redis.utils;
 
+import io.ballerina.lib.redis.exceptions.RedisConnectorException;
 import io.ballerina.runtime.api.creators.ErrorCreator;
 import io.ballerina.runtime.api.creators.TypeCreator;
 import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.types.PredefinedTypes;
+import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BArray;
 import io.ballerina.runtime.api.values.BError;
@@ -138,17 +140,32 @@ public class ConversionUtils {
      *
      * @param list the key value list
      * @return the Ballerina array
+     * @throws RedisConnectorException if any key in the list has no value
      */
-    public static <K> BArray createBStringArrayFromKeyValueList(List<KeyValue<K, String>> list) {
+    public static <K> BArray createBStringArrayFromKeyValueList(List<KeyValue<K, String>> list)
+            throws RedisConnectorException {
         BArray bStringArray = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
         for (KeyValue<K, String> item : list) {
-            String value;
-            try {
-                value = item.getValue();
-            } catch (NoSuchElementException e) {
-                value = null;
+            if (!item.hasValue()) {
+                throw new RedisConnectorException(Constants.MGET_NIL_VALUE_ERROR);
             }
-            bStringArray.append(StringUtils.fromString(value));
+            bStringArray.append(StringUtils.fromString(item.getValue()));
+        }
+        return bStringArray;
+    }
+
+    /**
+     * Create a nilable Ballerina array value from a key value list.
+     *
+     * @param list the key value list
+     * @return the Ballerina array
+     */
+    public static <K> BArray createBNilableStringArrayFromKeyValueList(List<KeyValue<K, String>> list) {
+        UnionType nilableStringType = TypeCreator.createUnionType(PredefinedTypes.TYPE_STRING,
+                PredefinedTypes.TYPE_NULL);
+        BArray bStringArray = ValueCreator.createArrayValue(TypeCreator.createArrayType(nilableStringType));
+        for (KeyValue<K, String> item : list) {
+            bStringArray.append(StringUtils.fromString(item.getValueOrElse(null)));
         }
         return bStringArray;
     }

--- a/native/src/main/java/io/ballerina/lib/redis/utils/ConversionUtils.java
+++ b/native/src/main/java/io/ballerina/lib/redis/utils/ConversionUtils.java
@@ -134,6 +134,26 @@ public class ConversionUtils {
     }
 
     /**
+     * Create a Ballerina array value from a key value list.
+     *
+     * @param list the key value list
+     * @return the Ballerina array
+     */
+    public static <K> BArray createBStringArrayFromKeyValueList(List<KeyValue<K, String>> list) {
+        BArray bStringArray = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
+        for (KeyValue<K, String> item : list) {
+            String value;
+            try {
+                value = item.getValue();
+            } catch (NoSuchElementException e) {
+                value = null;
+            }
+            bStringArray.append(StringUtils.fromString(value));
+        }
+        return bStringArray;
+    }
+
+    /**
      * Create a Java array from a Ballerina array value.
      *
      * @param bStringArray the Ballerina array value
@@ -155,20 +175,6 @@ public class ConversionUtils {
             map.put(entry.getKey().getValue(), entry.getValue().toString());
         }
         return map;
-    }
-
-    /**
-     * Create a Ballerina array value from a Ballerina map value.
-     *
-     * @param bMap the Ballerina map value
-     * @return the Ballerina array
-     */
-    public static BArray createBStringArrayFromBMap(BMap<BString, Object> bMap) {
-        BArray bStringArray = ValueCreator.createArrayValue(TypeCreator.createArrayType(PredefinedTypes.TYPE_STRING));
-        for (Map.Entry<BString, Object> entry : bMap.entrySet()) {
-            bStringArray.append(entry.getValue());
-        }
-        return bStringArray;
     }
 
     /**


### PR DESCRIPTION
## Purpose

Follow-up to #265, reworked per the discussion there to avoid a major version bump. Two separate fixes:

**1. `mGet` collapsing duplicate keys (fixes ballerina-platform/ballerina-library#8908)**

`mGet`'s native implementation round-tripped the Lettuce result through a keyed map, which can't hold two entries for the same key. A repeated key in the request collapsed to one entry, so the returned array was shorter than the request and no longer positionally aligned. Fixed by building the array directly from the ordered result instead — no signature change, not breaking.

**2. `mGet` failing on a missing key (addresses ballerina-platform/ballerina-library#8889)**

`mGet` still fails when a key doesn't exist, since Redis returns nil for a missing key but `mGet`'s return type is non-nilable. Changing `mGet`'s return type to fix this would be a breaking change, so instead:
- Added `mGetOptional`, a new function returning `string?[]|Error`, representing a missing key as `()`.
- `mGet` now fails with a clear message pointing to `mGetOptional` instead of the raw `InherentTypeViolation`.

`mGet` itself is otherwise unchanged (no `@deprecated`, left for a future major version decision).

## Examples

```ballerina
_ = check redis->set("present", "value");
_ = check redis->del(["absent"]);

// mGet: duplicate keys now preserved correctly
string[] r1 = check redis->mGet(["present", "present"]);
// -> ["value", "value"]

// mGet: missing key now fails with a clear message
string[]|redis:Error r2 = redis->mGet(["present", "absent"]);
// -> error: One or more keys returned nil, which cannot be represented in mGet. Use mGetOptional instead.

// mGetOptional: missing key represented as ()
string?[] r3 = check redis->mGetOptional(["present", "absent"]);
// -> ["value", ()]
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [ ] Checked native-image compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `mGet` to preserve duplicate keys and positional ordering in the returned results.
- Added a nil-safe variant `mGetOptional` to represent missing Redis keys as `()` entries (renamed from `mGetNilable` during review).
- Updated `mGet` behavior and messaging to fail with a clearer error that instructs callers to use `mGetOptional` when missing keys are possible.
- Refactored the underlying native `mGet` conversion logic to support the new missing-key handling.
- Added/updated tests, specification documentation, and changelog entries, and bumped the version to `3.4.0-SNAPSHOT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->