### PR TITLE
Update netty version to fix the security vulnerabilities

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.11.0"
 org="ballerinax"
 name = "redis"
-version = "3.3.0"
+version = "3.4.0"
 authors = ["Ballerina"]
 keywords = ["IT Operations/Database", "Cost/Freemium", "Vendor/Redis", "Area/Database", "Type/Connector"]
 icon = "icon.png"
@@ -16,8 +16,8 @@ graalvmCompatible = true
 groupId = "io.ballerina.lib"
 artifactId = "redis-native"
 module = "redis-native"
-version="3.3.0"
-path = "../native/build/libs/redis-native-3.3.0.jar"
+version="3.4.0-SNAPSHOT"
+path = "../native/build/libs/redis-native-3.4.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.lettuce"
@@ -44,56 +44,56 @@ path = "./lib/commons-io-2.14.0.jar"
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-common"
-version = "4.1.135.Final"
-path = "./lib/netty-common-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-common-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-buffer"
-version = "4.1.135.Final"
-path = "./lib/netty-buffer-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-buffer-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport"
-version = "4.1.135.Final"
-path = "./lib/netty-transport-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-transport-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-resolver"
-version = "4.1.135.Final"
-path = "./lib/netty-resolver-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-resolver-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-handler"
-version = "4.1.135.Final"
-path = "./lib/netty-handler-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-handler-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-kqueue"
-version = "4.1.135.Final"
-path = "./lib/netty-transport-native-kqueue-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-transport-native-kqueue-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-epoll"
-version = "4.1.135.Final"
-path = "./lib/netty-transport-native-epoll-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-transport-native-epoll-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-codec"
-version = "4.1.135.Final"
-path = "./lib/netty-codec-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-codec-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.netty"
 artifactId = "netty-transport-native-unix-common"
-version = "4.1.135.Final"
-path = "./lib/netty-transport-native-unix-common-4.1.135.Final.jar"
+version = "4.1.136.Final"
+path = "./lib/netty-transport-native-unix-common-4.1.136.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.projectreactor"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -345,7 +345,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "redis"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "http"},

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - [Fixed `mGet` returning fewer results than requested when the key list contained duplicates](https://github.com/ballerina-platform/ballerina-library/issues/8908)
 - [Fixed `mGet` failing with a raw `InherentTypeViolation` error when a key does not exist; it now fails with a clear message pointing to `mGetOptional`](https://github.com/ballerina-platform/ballerina-library/issues/8889)
+- [Update Netty version to 4.1.136.Final to fix security vulnerabilities](https://github.com/ballerina-platform/ballerina-library/issues/8924)
 
 ## [3.3.0] - 2026-07-06
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,6 @@ commonsPool2Version=2.11.1
 
 guavaVersion=32.0.0-jre
 commonsIoVersion=2.14.0
-nettyVersion=4.1.135.Final
+nettyVersion=4.1.136.Final
 reactorCoreVersion=3.6.2
 reactiveStreamsVersion=1.0.2


### PR DESCRIPTION
## Purpose

> $Subject

## Examples

N/A

## Checklist

- [x] Linked to an issue
- [x] Updated the changelog
- [ ] ~Added tests~
- [ ] ~Updated the spec~
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Netty to `4.1.136.Final` across build and dependency configuration.
- Updated Redis module versions and bundled artifact references to `3.4.0`.
- Documented the dependency update in the changelog to improve stability and address known issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->