### PR TITLE
Bump the minimum distribution to Swan Lake Update 12

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-distribution = "2201.11.0"
+distribution = "2201.12.0"
 org="ballerinax"
 name = "redis"
 version = "3.4.0"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.11.0"
+distribution-version = "2201.12.12"
 
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.13.0"
+version = "2.14.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.9.0"
+version = "3.10.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.6.0"
+version = "1.7.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -44,7 +44,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.8.0"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -56,7 +56,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.0.0"
+version = "1.1.4"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -66,7 +66,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.11.0"
+version = "1.13.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.13.8"
+version = "2.14.13"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},
@@ -112,7 +112,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.7.0"
+version = "1.8.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -130,7 +130,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.14.0"
+version = "2.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -241,7 +241,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.11.0"
+version = "2.14.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -256,7 +256,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.11.0"
+version = "2.12.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.13.0"
+version = "2.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "cache"},
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.4.0"
+version = "1.6.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.9.0"
+version = "1.10.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -304,11 +304,12 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.6.0"
+version = "2.11.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "time"}
+	{org = "ballerina", name = "time"},
+	{org = "ballerina", name = "uuid"}
 ]
 
 [[package]]
@@ -328,7 +329,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.6.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -336,10 +337,22 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.5.0"
+version = "2.6.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "uuid"
+version = "1.10.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "crypto"},
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.int"},
+	{org = "ballerina", name = "time"}
 ]
 
 [[package]]

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
-distribution = "2201.11.0"
+distribution = "2201.12.0"
 org="ballerinax"
 name = "redis"
 version = "@toml.version@"

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@ This file contains all the notable changes done to the Ballerina Redis package t
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Bumped the minimum supported Ballerina distribution to Swan Lake Update 12 (`2201.12.0`) and updated the locked dependency versions accordingly, so that no dependency is resolved from a distribution older than Update 12
+
 ## [3.4.0] - 2026-07-24
 
 ### Added

--- a/examples/cache-management/Ballerina.toml
+++ b/examples/cache-management/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "nino"
 name = "cache_management"
 version = "0.1.0"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "2201.12.0"
 
 [build-options]
 observabilityIncluded = true

--- a/examples/rate-limiting/Ballerina.toml
+++ b/examples/rate-limiting/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "nino"
 name = "rate_limiting"
 version = "0.1.0"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "2201.12.0"
 
 [build-options]
 observabilityIncluded = true

--- a/examples/session-management/Ballerina.toml
+++ b/examples/session-management/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "nino"
 name = "session_management"
 version = "0.1.0"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "2201.12.0"
 
 [build-options]
 observabilityIncluded = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib.redis
 version=3.4.1-SNAPSHOT
-ballerinaLangVersion=2201.11.0
+ballerinaLangVersion=2201.12.12
 
 checkstylePluginVersion=10.12.1
 spotbugsPluginVersion=6.0.18


### PR DESCRIPTION
## Purpose

Builds of packages that depend on this connector emit the following warning, because the connector's published dependency graph still declares dependency versions that were published against a pre-Update 12 distribution:

```
WARNING [automation] The following transitive dependencies were published with a distribution older
than Swan Lake Update 12. It is recommended to execute 'bal build --locking-mode=soft' to
ensure compatibility:
        - ballerina/crypto:2.8.0
        - ballerina/time:2.6.0
```

This PR removes that warning at the source by bumping the distribution and re-resolving the lock file.

## Changes

- `distribution` to `2201.12.0` in `build-config/resources/Ballerina.toml` (and the generated `ballerina/Ballerina.toml`) and in the three example packages.
- `ballerinaLangVersion` to `2201.12.12`.
- `ballerina/Dependencies.toml` re-resolved on Update 12: **`ballerina/crypto` 2.8.0 to 2.12.1**, **`ballerina/time` 2.6.0 to 2.8.1**, plus the test-scope dependencies that came with them.
- Changelog entry under a new `[Unreleased]` section.
